### PR TITLE
Allow aliases to IdentifierExpressions.

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -369,6 +369,10 @@ func (me *datasetTest) TestLiteralAliasedExpression() {
 	assert.NoError(t, ds.Literal(me.Truncate(buf), Literal("count(*)").As("count")))
 	assert.Equal(t, buf.args, []interface{}{})
 	assert.Equal(t, buf.String(), `count(*) AS "count"`)
+
+	buf = NewSqlBuilder(false)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), I("a").As(I("b"))))
+	assert.Equal(t, buf.String(), `"a" AS "b"`)
 }
 
 func (me *datasetTest) TestBooleanExpression() {

--- a/example_test.go
+++ b/example_test.go
@@ -136,13 +136,13 @@ func ExampleAliasMethods() {
 	sql, _, _ = db.From("test").Select(goqu.L("sum(amount)").As("total_amount")).ToSql()
 	fmt.Println(sql)
 
-	sql, _, _ = db.From("test").Select(goqu.I("test.a").As(goqu.I("test.b"))).ToSql()
+	sql, _, _ = db.From("test").Select(goqu.I("a").As(goqu.I("as_a"))).ToSql()
 	fmt.Println(sql)
 	// Output:
 	// SELECT "a" AS "as_a" FROM "test"
 	// SELECT COUNT(*) AS "count" FROM "test"
 	// SELECT sum(amount) AS "total_amount" FROM "test"
-	// SELECT "test"."a" AS "test"."b" FROM "test"
+	// SELECT "a" AS "as_a" FROM "test"
 
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -135,10 +135,14 @@ func ExampleAliasMethods() {
 
 	sql, _, _ = db.From("test").Select(goqu.L("sum(amount)").As("total_amount")).ToSql()
 	fmt.Println(sql)
+
+	sql, _, _ = db.From("test").Select(goqu.I("test.a").As(goqu.I("test.b"))).ToSql()
+	fmt.Println(sql)
 	// Output:
 	// SELECT "a" AS "as_a" FROM "test"
 	// SELECT COUNT(*) AS "count" FROM "test"
 	// SELECT sum(amount) AS "total_amount" FROM "test"
+	// SELECT "test"."a" AS "test"."b" FROM "test"
 
 }
 


### PR DESCRIPTION
This allows goqu.I("col").As(goqu.I("other")) as well as the original goqu.I("col").As("other").