### PR TITLE
Update ScanStruct to parse structs for column names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v1.0.1
+
+* When scanning a struct or slice of structs, the struct(s) will be parsed for the column names to select. [#9](https://github.com/doug-martin/goqu/pull/9) - [@technotronicoz](https://github.com/TechnotronicOz)
+
 ## v1.0.0
 
 * You can now passed an IdentiferExpression to `As` [#8](https://github.com/doug-martin/goqu/pull/8) - [@croachrose](https://github.com/croachrose)

--- a/adapters/mysql/dataset_adapter_test.go
+++ b/adapters/mysql/dataset_adapter_test.go
@@ -1,3 +1,4 @@
+// +build mysql
 package mysql
 
 import (

--- a/adapters/mysql/dataset_adapter_test.go
+++ b/adapters/mysql/dataset_adapter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/doug-martin/goqu"
-	"github.com/stretchr/testify/assert"
+	"github.com/technotronicoz/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/adapters/mysql/mysql_test.go
+++ b/adapters/mysql/mysql_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/doug-martin/goqu"
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 const (

--- a/adapters/mysql/mysql_test.go
+++ b/adapters/mysql/mysql_test.go
@@ -1,3 +1,4 @@
+// +build mysql
 package mysql
 
 import (

--- a/adapters/postgres/dataset_adapter_test.go
+++ b/adapters/postgres/dataset_adapter_test.go
@@ -2,10 +2,11 @@
 package postgres
 
 import (
-	"github.com/doug-martin/goqu"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/doug-martin/goqu"
+	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type datasetAdapterTest struct {

--- a/adapters/postgres/dataset_adapter_test.go
+++ b/adapters/postgres/dataset_adapter_test.go
@@ -1,3 +1,4 @@
+// +build postgres
 package postgres
 
 import (

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1,3 +1,4 @@
+// +build postgres
 package postgres
 
 import (

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/doug-martin/goqu"
 	"github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 const schema = `

--- a/adapters/sqlite3/dataset_adapter_test.go
+++ b/adapters/sqlite3/dataset_adapter_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/doug-martin/goqu"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type datasetAdapterTest struct {

--- a/adapters/sqlite3/dataset_adapter_test.go
+++ b/adapters/sqlite3/dataset_adapter_test.go
@@ -1,3 +1,4 @@
+// +build sqlite3
 package sqlite3
 
 import (

--- a/adapters/sqlite3/sqlite3_test.go
+++ b/adapters/sqlite3/sqlite3_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/doug-martin/goqu"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 const (

--- a/adapters/sqlite3/sqlite3_test.go
+++ b/adapters/sqlite3/sqlite3_test.go
@@ -1,3 +1,4 @@
+// +build sqlite3
 package sqlite3
 
 import (

--- a/adapters_test.go
+++ b/adapters_test.go
@@ -1,9 +1,10 @@
 package goqu
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type adapterTest struct {

--- a/crud_exec.go
+++ b/crud_exec.go
@@ -306,7 +306,11 @@ func getTypeInfo(i interface{}, val reflect.Value) (reflect.Type, reflect.Kind, 
 	isSliceOfPointers := false
 	valKind := val.Kind()
 	if valKind == reflect.Slice {
-		t = reflect.TypeOf(i).Elem().Elem()
+		if reflect.ValueOf(i).Kind() == reflect.Ptr {
+			t = reflect.TypeOf(i).Elem().Elem()
+		} else {
+			t = reflect.TypeOf(i).Elem()
+		}
 		if t.Kind() == reflect.Ptr {
 			isSliceOfPointers = true
 			t = t.Elem()

--- a/crud_exec_test.go
+++ b/crud_exec_test.go
@@ -2,10 +2,11 @@ package goqu
 
 import (
 	"fmt"
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type testCrudActionItem struct {

--- a/database_test.go
+++ b/database_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type testActionItem struct {

--- a/dataset_actions.go
+++ b/dataset_actions.go
@@ -1,10 +1,16 @@
 package goqu
 
-//Generates the SELECT sql for this dataset and uses Exec#ScanStructs to scan the results into a slice of structs
+//Generates the SELECT sql for this dataset and uses Exec#ScanStructs to scan the results into a slice of structs.
+// When using this method, ScanStructs will only select the columns that can be scanned in to the struct unless you
+// have explicitly selected certain columns. See examples.
 //
 //i: A pointer to a slice of structs
 func (me *Dataset) ScanStructs(i interface{}) error {
-	sql, args, err := me.ToSql()
+	ds := me
+	if me.isDefaultSelect() {
+		ds = ds.Select(i)
+	}
+	sql, args, err := ds.ToSql()
 	return newCrudExec(me.database, err, sql, args...).ScanStructs(i)
 }
 
@@ -12,7 +18,11 @@ func (me *Dataset) ScanStructs(i interface{}) error {
 //
 //i: A pointer to a structs
 func (me *Dataset) ScanStruct(i interface{}) (bool, error) {
-	sql, args, err := me.Limit(1).ToSql()
+	ds := me.Limit(1)
+	if me.isDefaultSelect() {
+		ds = ds.Select(i)
+	}
+	sql, args, err := ds.ToSql()
 	return newCrudExec(me.database, err, sql, args...).ScanStruct(i)
 }
 

--- a/dataset_actions_test.go
+++ b/dataset_actions_test.go
@@ -14,7 +14,7 @@ func (me *datasetTest) TestScanStructs() {
 	t := me.T()
 	mDb, err := sqlmock.New()
 	assert.NoError(t, err)
-	sqlmock.ExpectQuery(`SELECT \* FROM "items"`).
+	sqlmock.ExpectQuery(`SELECT "address", "name" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
@@ -42,7 +42,7 @@ func (me *datasetTest) TestScanStructs_WithPreparedStatements() {
 	t := me.T()
 	mDb, err := sqlmock.New()
 	assert.NoError(t, err)
-	sqlmock.ExpectQuery(`SELECT \* FROM "items" WHERE \(\("address" = \?\) AND \("name" IN \(\?, \?, \?\)\)\)`).
+	sqlmock.ExpectQuery(`SELECT "address", "name" FROM "items" WHERE \(\("address" = \?\) AND \("name" IN \(\?, \?, \?\)\)\)`).
 		WithArgs("111 Test Addr", "Bob", "Sally", "Billy").
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
@@ -74,7 +74,7 @@ func (me *datasetTest) TestScanStruct() {
 	t := me.T()
 	mDb, err := sqlmock.New()
 	assert.NoError(t, err)
-	sqlmock.ExpectQuery(`SELECT \* FROM "items" LIMIT 1`).
+	sqlmock.ExpectQuery(`SELECT "address", "name" FROM "items" LIMIT 1`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).FromCSVString("111 Test Addr,Test1"))
 
@@ -102,7 +102,7 @@ func (me *datasetTest) TestScanStruct_WithPreparedStatements() {
 	t := me.T()
 	mDb, err := sqlmock.New()
 	assert.NoError(t, err)
-	sqlmock.ExpectQuery(`SELECT \* FROM "items" WHERE \(\("address" = \?\) AND \("name" IN \(\?, \?, \?\)\)\) LIMIT \?`).
+	sqlmock.ExpectQuery(`SELECT "address", "name" FROM "items" WHERE \(\("address" = \?\) AND \("name" IN \(\?, \?, \?\)\)\) LIMIT \?`).
 		WithArgs("111 Test Addr", "Bob", "Sally", "Billy", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).FromCSVString("111 Test Addr,Test1"))
 

--- a/dataset_actions_test.go
+++ b/dataset_actions_test.go
@@ -2,7 +2,7 @@ package goqu
 
 import (
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type dsTestActionItem struct {

--- a/dataset_delete_test.go
+++ b/dataset_delete_test.go
@@ -2,7 +2,7 @@ package goqu
 
 import (
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
+	"github.com/technotronicoz/testify/assert"
 )
 
 func (me *datasetTest) TestDeleteSqlNoReturning() {

--- a/dataset_insert_test.go
+++ b/dataset_insert_test.go
@@ -2,7 +2,7 @@ package goqu
 
 import (
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
+	"github.com/technotronicoz/testify/assert"
 )
 
 func (me *datasetTest) TestInsertSqlNoReturning() {

--- a/dataset_select.go
+++ b/dataset_select.go
@@ -22,6 +22,7 @@ var (
 //   Dataset: Will use the SQL generated from that Dataset. If the dataset is aliased it will use that alias as the column name.
 //   LiteralExpression: (See Literal) Will use the literal SQL
 //   SqlFunction: (See Func, MIN, MAX, COUNT....)
+//   Struct: If passing in an instance of a struct, we will parse the struct for the column names to select. See examples
 func (me *Dataset) Select(selects ...interface{}) *Dataset {
 	ret := me.copy()
 	ret.clauses.SelectDistinct = nil
@@ -35,6 +36,7 @@ func (me *Dataset) Select(selects ...interface{}) *Dataset {
 //   Dataset: Will use the SQL generated from that Dataset. If the dataset is aliased it will use that alias as the column name.
 //   LiteralExpression: (See Literal) Will use the literal SQL
 //   SqlFunction: (See Func, MIN, MAX, COUNT....)
+//   Struct: If passing in an instance of a struct, we will parse the struct for the column names to select. See examples
 func (me *Dataset) SelectDistinct(selects ...interface{}) *Dataset {
 	ret := me.copy()
 	ret.clauses.Select = nil
@@ -47,6 +49,18 @@ func (me *Dataset) ClearSelect() *Dataset {
 	ret := me.copy()
 	ret.clauses.Select = cols(Literal("*"))
 	ret.clauses.SelectDistinct = nil
+	return ret
+}
+
+//Returns true if using default SELECT *
+func (me *Dataset) isDefaultSelect() bool {
+	ret := false
+	selects := me.clauses.Select.Columns()
+	if len(selects) == 1 {
+		if l, ok := selects[0].(LiteralExpression); ok && l.Literal() == "*" {
+			ret = true
+		}
+	}
 	return ret
 }
 

--- a/dataset_select_test.go
+++ b/dataset_select_test.go
@@ -56,6 +56,41 @@ func (me *datasetTest) TestSelect() {
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT("a") AS "distinct", COUNT("a") AS "count", CASE WHEN (MIN("a") = 10) THEN TRUE ELSE FALSE END, CASE WHEN (AVG("a") != 10) THEN TRUE ELSE FALSE END, CASE WHEN (FIRST("a") > 10) THEN TRUE ELSE FALSE END, CASE WHEN (FIRST("a") >= 10) THEN TRUE ELSE FALSE END, CASE WHEN (LAST("a") < 10) THEN TRUE ELSE FALSE END, CASE WHEN (LAST("a") <= 10) THEN TRUE ELSE FALSE END, SUM("a") AS "sum", COALESCE("a", 'a') AS "colaseced"`)
 
+	type myStruct struct {
+		Name         string
+		Address      string `db:"address"`
+		EmailAddress string `db:"email_address"`
+	}
+	sql, _, err = ds1.Select(&myStruct{}).ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
+
+	sql, _, err = ds1.Select(myStruct{}).ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
+
+	type myStruct2 struct {
+		myStruct
+		Zipcode string `db:"zipcode"`
+	}
+
+	sql, _, err = ds1.Select(&myStruct2{}).ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT "address", "email_address", "name", "zipcode" FROM "test"`)
+
+	sql, _, err = ds1.Select(myStruct2{}).ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT "address", "email_address", "name", "zipcode" FROM "test"`)
+
+	var myStructs []myStruct
+	sql, _, err = ds1.Select(&myStructs).ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
+
+	sql, _, err = ds1.Select(myStructs).ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
+
 	//should not change original
 	sql, _, err = ds1.ToSql()
 	assert.NoError(t, err)

--- a/dataset_select_test.go
+++ b/dataset_select_test.go
@@ -1,7 +1,7 @@
 package goqu
 
 import (
-	"github.com/stretchr/testify/assert"
+	"github.com/technotronicoz/testify/assert"
 )
 
 func (me *datasetTest) TestSelect() {

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/technotronicoz/testify/assert"
 )
 
 type datasetTest struct {

--- a/dataset_update_test.go
+++ b/dataset_update_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
+	"github.com/technotronicoz/testify/assert"
 )
 
 func (me *datasetTest) TestUpdateSqlWithNoSources() {

--- a/example_test.go
+++ b/example_test.go
@@ -1095,6 +1095,51 @@ func ExampleDataset_Select_withSqlFunctionExpression() {
 	// SELECT COUNT(*) AS "age_count", MAX("age") AS "max_age", AVG("age") AS "avg_age" FROM "test"
 }
 
+func ExampleDataset_Select_withStruct() {
+	db := goqu.New("default", driver)
+	ds := db.From("test")
+
+	type myStruct struct {
+		Name         string
+		Address      string `db:"address"`
+		EmailAddress string `db:"email_address"`
+	}
+
+	// Pass with pointer
+	sql, _, _ := ds.Select(&myStruct{}).ToSql()
+	fmt.Println(sql)
+
+	// Pass instance of
+	sql, _, _ = ds.Select(myStruct{}).ToSql()
+	fmt.Println(sql)
+
+	type myStruct2 struct {
+		myStruct
+		Zipcode string `db:"zipcode"`
+	}
+
+	// Pass pointer to struct with embedded struct
+	sql, _, _ = ds.Select(&myStruct2{}).ToSql()
+	fmt.Println(sql)
+
+	// Pass instance of struct with embedded struct
+	sql, _, _ = ds.Select(myStruct2{}).ToSql()
+	fmt.Println(sql)
+
+	var myStructs []myStruct
+
+	// Pass slice of structs, will only select columns from underlying type
+	sql, _, _ = ds.Select(myStructs).ToSql()
+	fmt.Println(sql)
+
+	// Output:
+	// SELECT "address", "email_address", "name" FROM "test"
+	// SELECT "address", "email_address", "name" FROM "test"
+	// SELECT "address", "email_address", "name", "zipcode" FROM "test"
+	// SELECT "address", "email_address", "name", "zipcode" FROM "test"
+	// SELECT "address", "email_address", "name" FROM "test"
+}
+
 func ExampleDataset_SelectDistinct() {
 	db := goqu.New("default", driver)
 	sql, _, _ := db.From("test").SelectDistinct("a", "b").ToSql()

--- a/expressions.go
+++ b/expressions.go
@@ -228,7 +228,25 @@ func cols(vals ...interface{}) ColumnList {
 		case Expression:
 			cols = append(cols, val.(Expression))
 		default:
-			panic(fmt.Sprintf("Cannot created expression from  %+v", val))
+			_, valKind, _ := getTypeInfo(val, reflect.Indirect(reflect.ValueOf(val)))
+
+			if valKind == reflect.Struct {
+				cm, err := getColumnMap(val)
+				if err != nil {
+					panic(err.Error())
+				}
+				var structCols []string
+				for key, _ := range cm {
+					structCols = append(structCols, key)
+				}
+				sort.Strings(structCols)
+				for _, col := range structCols {
+					cols = append(cols, I(col))
+				}
+			} else {
+				panic(fmt.Sprintf("Cannot created expression from  %+v", val))
+			}
+
 		}
 	}
 	return columnList{columns: cols}


### PR DESCRIPTION
Update scan struct to parse the struct(s) and for the column names to be selected.