### PR TITLE
Add literal bytes and update to c2fo testify

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -133,6 +133,10 @@ type (
 		//
 		//buf: The current SqlBuilder to write the sql to
 		LiteralString(buf *SqlBuilder, s string) error
+		//Generates SQL value for a Slice of Bytes
+		//
+		//buf: The current SqlBuilder to write the sql to
+		LiteralBytes(buf *SqlBuilder, bs []byte) error
 		//Generates SQL value for a Slice
 		//
 		//buf: The current SqlBuilder to write the sql to

--- a/adapters/mysql/dataset_adapter_test.go
+++ b/adapters/mysql/dataset_adapter_test.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 	"gopkg.in/doug-martin/goqu.v3"
 )
 

--- a/adapters/mysql/mysql_test.go
+++ b/adapters/mysql/mysql_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
 	"gopkg.in/doug-martin/goqu.v3"
 )
 

--- a/adapters/postgres/dataset_adapter_test.go
+++ b/adapters/postgres/dataset_adapter_test.go
@@ -3,8 +3,8 @@ package postgres
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/suite"
+	"github.com/c2fo/testify/assert"
 	"gopkg.in/doug-martin/goqu.v3"
 )
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 	"github.com/lib/pq"
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
 	"gopkg.in/doug-martin/goqu.v3"
 )
 

--- a/adapters/sqlite3/dataset_adapter_test.go
+++ b/adapters/sqlite3/dataset_adapter_test.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/suite"
+	"github.com/c2fo/testify/assert"
 	"gopkg.in/doug-martin/goqu.v3"
 )
 

--- a/adapters/sqlite3/sqlite3_test.go
+++ b/adapters/sqlite3/sqlite3_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
 	"gopkg.in/doug-martin/goqu.v3"
 )
 

--- a/adapters_test.go
+++ b/adapters_test.go
@@ -3,8 +3,8 @@ package goqu
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 )
 
 type adapterTest struct {

--- a/crud_exec_test.go
+++ b/crud_exec_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 )
 
 type testCrudActionItem struct {

--- a/database_test.go
+++ b/database_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/suite"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/suite"
 )
 
 type testActionItem struct {

--- a/dataset.go
+++ b/dataset.go
@@ -194,10 +194,10 @@ func (me *Dataset) Literal(buf *SqlBuilder, val interface{}) error {
 		return me.adapter.LiteralFloat(buf, v)
 	} else if v, ok := val.(string); ok {
 		return me.adapter.LiteralString(buf, v)
+	} else if v, ok := val.([]byte); ok {
+		return me.adapter.LiteralBytes(buf, v)
 	} else if v, ok := val.(bool); ok {
 		return me.adapter.LiteralBool(buf, v)
-	} else if v, ok := val.([]byte); ok {
-		return me.adapter.LiteralString(buf, string(v))
 	} else if v, ok := val.(time.Time); ok {
 		return me.adapter.LiteralTime(buf, v)
 	} else if v, ok := val.(*time.Time); ok {

--- a/dataset_actions_test.go
+++ b/dataset_actions_test.go
@@ -2,7 +2,7 @@ package goqu
 
 import (
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 type dsTestActionItem struct {

--- a/dataset_delete_test.go
+++ b/dataset_delete_test.go
@@ -2,7 +2,7 @@ package goqu
 
 import (
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 func (me *datasetTest) TestDeleteSqlNoReturning() {

--- a/dataset_insert_test.go
+++ b/dataset_insert_test.go
@@ -2,7 +2,7 @@ package goqu
 
 import (
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
 
 	"time"
 )

--- a/dataset_select_test.go
+++ b/dataset_select_test.go
@@ -1,7 +1,7 @@
 package goqu
 
 import (
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 func (me *datasetTest) TestSelect() {

--- a/dataset_update_test.go
+++ b/dataset_update_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/technotronicoz/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 func (me *datasetTest) TestUpdateSqlWithNoSources() {
@@ -244,7 +244,7 @@ func (me *datasetTest) TestPreparedUpdateSqlWithByteSlice() {
 	}
 	sql, args, err := ds1.Returning(I("items").All()).Prepared(true).ToUpdateSql(item{Name: "Test", Data: []byte(`{"someJson":"data"}`)})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"Test", `{"someJson":"data"}`})
+	assert.Equal(t, args, []interface{}{"Test", []byte(`{"someJson":"data"}`)})
 	assert.Equal(t, sql, `UPDATE "items" SET "name"=?,"data"=? RETURNING "items".*`)
 }
 
@@ -257,7 +257,7 @@ func (me *datasetTest) TestPreparedUpdateSqlWithValuer() {
 	}
 	sql, args, err := ds1.Returning(I("items").All()).Prepared(true).ToUpdateSql(item{Name: "Test", Data: []byte(`Hello`)})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"Test", "Hello World"})
+	assert.Equal(t, args, []interface{}{"Test", []byte("Hello World")})
 	assert.Equal(t, sql, `UPDATE "items" SET "name"=?,"data"=? RETURNING "items".*`)
 }
 

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 var (
@@ -633,6 +634,28 @@ func (me *DefaultAdapter) LiteralString(buf *SqlBuilder, s string) error {
 		}
 	}
 
+	buf.WriteRune(me.StringQuote)
+	return nil
+}
+
+// Generates SQL for a slice of bytes
+func (me *DefaultAdapter) LiteralBytes(buf *SqlBuilder, bs []byte) error {
+	if buf.IsPrepared {
+		return me.PlaceHolderSql(buf, bs)
+	}
+	buf.WriteRune(me.StringQuote)
+	i := 0
+	for len(bs) > 0 {
+		char, l := utf8.DecodeRune(bs)
+		if char == me.StringQuote { // single quote: ' -> \'
+			buf.WriteRune(me.StringQuote)
+			buf.WriteRune(me.StringQuote)
+		} else {
+			buf.WriteRune(char)
+		}
+		i++
+		bs = bs[l:]
+	}
 	buf.WriteRune(me.StringQuote)
 	return nil
 }


### PR DESCRIPTION
* Add support for accepting a slice of bytes for literal serialization
* Updated Goqu to use C2FO fork of Testify