### PR TITLE
Fix issue #19 - Exec.ScanStruct does not allow embedded pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 go:
   - 1.3
   - 1.4
+  - 1.5
   - tip
 
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v3.1.2
+
+* Fixing ScanStruct issue with embedded pointers in crud_exec [#20](https://github.com/doug-martin/goqu/pull/20) - [@ruzz311](https://github.com/ruzz311)
+
 ## v3.1.1
 
 * Fixing race condition with struct_map_cache in crud_exec [#18](https://github.com/doug-martin/goqu/pull/18) - [@andymoon](https://github.com/andymoon), [@aheuermann](https://github.com/aheuermann)
@@ -8,7 +12,7 @@
     * Fix an issue with a nil pointer access on the inserts and updates.
     * Allowing ScanStructs to take a struct with an embedded pointer to a struct.
     * Change to check if struct is Anonymous when recursing through an embedded struct.
-    * Updated to use the lastest version of github.com/DATA-DOG/go-sqlmock.
+    * Updated to use the latest version of github.com/DATA-DOG/go-sqlmock.
 
 ## v3.0.1
 

--- a/crud_exec.go
+++ b/crud_exec.go
@@ -224,6 +224,7 @@ func assignVals(i interface{}, results []Record, cm columnMap) error {
 	switch val.Kind() {
 	case reflect.Struct:
 		result := results[0]
+		initEmbeddedPtr(val)
 		for name, data := range cm {
 			src, ok := result[name]
 			if ok {

--- a/dataset_insert_test.go
+++ b/dataset_insert_test.go
@@ -61,24 +61,24 @@ func (me *datasetTest) TestInsertSqlWithStructs() {
 func (me *datasetTest) TestInsertSqlWithEmbeddedStruct() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string `db:"primary_phone"`
 		Home    string `db:"home_phone"`
 	}
 	type item struct {
-		phone
+		Phone
 		Address string `db:"address"`
 		Name    string `db:"name"`
 	}
-	sql, _, err := ds1.ToInsertSql(item{Name: "Test", Address: "111 Test Addr", phone: phone{Home: "123123", Primary: "456456"}})
+	sql, _, err := ds1.ToInsertSql(item{Name: "Test", Address: "111 Test Addr", Phone: Phone{Home: "123123", Primary: "456456"}})
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES ('456456', '123123', '111 Test Addr', 'Test')`)
 
 	sql, _, err = ds1.ToInsertSql(
-		item{Address: "111 Test Addr", Name: "Test1", phone: phone{Home: "123123", Primary: "456456"}},
-		item{Address: "211 Test Addr", Name: "Test2", phone: phone{Home: "123123", Primary: "456456"}},
-		item{Address: "311 Test Addr", Name: "Test3", phone: phone{Home: "123123", Primary: "456456"}},
-		item{Address: "411 Test Addr", Name: "Test4", phone: phone{Home: "123123", Primary: "456456"}},
+		item{Address: "111 Test Addr", Name: "Test1", Phone: Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "211 Test Addr", Name: "Test2", Phone: Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "311 Test Addr", Name: "Test3", Phone: Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "411 Test Addr", Name: "Test4", Phone: Phone{Home: "123123", Primary: "456456"}},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES ('456456', '123123', '111 Test Addr', 'Test1'), ('456456', '123123', '211 Test Addr', 'Test2'), ('456456', '123123', '311 Test Addr', 'Test3'), ('456456', '123123', '411 Test Addr', 'Test4')`)
@@ -87,25 +87,25 @@ func (me *datasetTest) TestInsertSqlWithEmbeddedStruct() {
 func (me *datasetTest) TestInsertSqlWithEmbeddedStructPtr() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string `db:"primary_phone"`
 		Home    string `db:"home_phone"`
 	}
 	type item struct {
-		*phone
+		*Phone
 		Address string        `db:"address"`
 		Name    string        `db:"name"`
 		Valuer  sql.NullInt64 `db:"valuer"`
 	}
-	sql, _, err := ds1.ToInsertSql(item{Name: "Test", Address: "111 Test Addr", Valuer: sql.NullInt64{Int64: 10, Valid: true}, phone: &phone{Home: "123123", Primary: "456456"}})
+	sql, _, err := ds1.ToInsertSql(item{Name: "Test", Address: "111 Test Addr", Valuer: sql.NullInt64{Int64: 10, Valid: true}, Phone: &Phone{Home: "123123", Primary: "456456"}})
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name", "valuer") VALUES ('456456', '123123', '111 Test Addr', 'Test', 10)`)
 
 	sql, _, err = ds1.ToInsertSql(
-		item{Address: "111 Test Addr", Name: "Test1", phone: &phone{Home: "123123", Primary: "456456"}},
-		item{Address: "211 Test Addr", Name: "Test2", phone: &phone{Home: "123123", Primary: "456456"}},
-		item{Address: "311 Test Addr", Name: "Test3", phone: &phone{Home: "123123", Primary: "456456"}},
-		item{Address: "411 Test Addr", Name: "Test4", phone: &phone{Home: "123123", Primary: "456456"}},
+		item{Address: "111 Test Addr", Name: "Test1", Phone: &Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "211 Test Addr", Name: "Test2", Phone: &Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "311 Test Addr", Name: "Test3", Phone: &Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "411 Test Addr", Name: "Test4", Phone: &Phone{Home: "123123", Primary: "456456"}},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name", "valuer") VALUES ('456456', '123123', '111 Test Addr', 'Test1', NULL), ('456456', '123123', '211 Test Addr', 'Test2', NULL), ('456456', '123123', '311 Test Addr', 'Test3', NULL), ('456456', '123123', '411 Test Addr', 'Test4', NULL)`)
@@ -481,25 +481,25 @@ func (me *datasetTest) TestPreparedInsertDefaultValues() {
 func (me *datasetTest) TestPreparedInsertSqlWithEmbeddedStruct() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string `db:"primary_phone"`
 		Home    string `db:"home_phone"`
 	}
 	type item struct {
-		phone
+		Phone
 		Address string `db:"address"`
 		Name    string `db:"name"`
 	}
-	sql, args, err := ds1.Prepared(true).ToInsertSql(item{Name: "Test", Address: "111 Test Addr", phone: phone{Home: "123123", Primary: "456456"}})
+	sql, args, err := ds1.Prepared(true).ToInsertSql(item{Name: "Test", Address: "111 Test Addr", Phone: Phone{Home: "123123", Primary: "456456"}})
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{"456456", "123123", "111 Test Addr", "Test"})
 	assert.Equal(t, sql, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES (?, ?, ?, ?)`)
 
 	sql, args, err = ds1.Prepared(true).ToInsertSql(
-		item{Address: "111 Test Addr", Name: "Test1", phone: phone{Home: "123123", Primary: "456456"}},
-		item{Address: "211 Test Addr", Name: "Test2", phone: phone{Home: "123123", Primary: "456456"}},
-		item{Address: "311 Test Addr", Name: "Test3", phone: phone{Home: "123123", Primary: "456456"}},
-		item{Address: "411 Test Addr", Name: "Test4", phone: phone{Home: "123123", Primary: "456456"}},
+		item{Address: "111 Test Addr", Name: "Test1", Phone: Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "211 Test Addr", Name: "Test2", Phone: Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "311 Test Addr", Name: "Test3", Phone: Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "411 Test Addr", Name: "Test4", Phone: Phone{Home: "123123", Primary: "456456"}},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{
@@ -514,25 +514,25 @@ func (me *datasetTest) TestPreparedInsertSqlWithEmbeddedStruct() {
 func (me *datasetTest) TestPreparedInsertSqlWithEmbeddedStructPtr() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string `db:"primary_phone"`
 		Home    string `db:"home_phone"`
 	}
 	type item struct {
-		*phone
+		*Phone
 		Address string `db:"address"`
 		Name    string `db:"name"`
 	}
-	sql, args, err := ds1.Prepared(true).ToInsertSql(item{Name: "Test", Address: "111 Test Addr", phone: &phone{Home: "123123", Primary: "456456"}})
+	sql, args, err := ds1.Prepared(true).ToInsertSql(item{Name: "Test", Address: "111 Test Addr", Phone: &Phone{Home: "123123", Primary: "456456"}})
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{"456456", "123123", "111 Test Addr", "Test"})
 	assert.Equal(t, sql, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES (?, ?, ?, ?)`)
 
 	sql, args, err = ds1.Prepared(true).ToInsertSql(
-		item{Address: "111 Test Addr", Name: "Test1", phone: &phone{Home: "123123", Primary: "456456"}},
-		item{Address: "211 Test Addr", Name: "Test2", phone: &phone{Home: "123123", Primary: "456456"}},
-		item{Address: "311 Test Addr", Name: "Test3", phone: &phone{Home: "123123", Primary: "456456"}},
-		item{Address: "411 Test Addr", Name: "Test4", phone: &phone{Home: "123123", Primary: "456456"}},
+		item{Address: "111 Test Addr", Name: "Test1", Phone: &Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "211 Test Addr", Name: "Test2", Phone: &Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "311 Test Addr", Name: "Test3", Phone: &Phone{Home: "123123", Primary: "456456"}},
+		item{Address: "411 Test Addr", Name: "Test4", Phone: &Phone{Home: "123123", Primary: "456456"}},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{

--- a/dataset_select_test.go
+++ b/dataset_select_test.go
@@ -56,22 +56,22 @@ func (me *datasetTest) TestSelect() {
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT("a") AS "distinct", COUNT("a") AS "count", CASE WHEN (MIN("a") = 10) THEN TRUE ELSE FALSE END, CASE WHEN (AVG("a") != 10) THEN TRUE ELSE FALSE END, CASE WHEN (FIRST("a") > 10) THEN TRUE ELSE FALSE END, CASE WHEN (FIRST("a") >= 10) THEN TRUE ELSE FALSE END, CASE WHEN (LAST("a") < 10) THEN TRUE ELSE FALSE END, CASE WHEN (LAST("a") <= 10) THEN TRUE ELSE FALSE END, SUM("a") AS "sum", COALESCE("a", 'a') AS "colaseced"`)
 
-	type myStruct struct {
+	type MyStruct struct {
 		Name         string
 		Address      string `db:"address"`
 		EmailAddress string `db:"email_address"`
 		FakeCol      string `db:"-"`
 	}
-	sql, _, err = ds1.Select(&myStruct{}).ToSql()
+	sql, _, err = ds1.Select(&MyStruct{}).ToSql()
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
 
-	sql, _, err = ds1.Select(myStruct{}).ToSql()
+	sql, _, err = ds1.Select(MyStruct{}).ToSql()
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
 
 	type myStruct2 struct {
-		myStruct
+		MyStruct
 		Zipcode string `db:"zipcode"`
 	}
 
@@ -83,7 +83,7 @@ func (me *datasetTest) TestSelect() {
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT "address", "email_address", "name", "zipcode" FROM "test"`)
 
-	var myStructs []myStruct
+	var myStructs []MyStruct
 	sql, _, err = ds1.Select(&myStructs).ToSql()
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT "address", "email_address", "name" FROM "test"`)
@@ -122,22 +122,22 @@ func (me *datasetTest) TestSelectDistinct() {
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT "id" AS "other_id", COUNT(*) AS "count" FROM "test"`)
 
-	type myStruct struct {
+	type MyStruct struct {
 		Name         string
 		Address      string `db:"address"`
 		EmailAddress string `db:"email_address"`
 		FakeCol      string `db:"-"`
 	}
-	sql, _, err = ds1.SelectDistinct(&myStruct{}).ToSql()
+	sql, _, err = ds1.SelectDistinct(&MyStruct{}).ToSql()
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT "address", "email_address", "name" FROM "test"`)
 
-	sql, _, err = ds1.SelectDistinct(myStruct{}).ToSql()
+	sql, _, err = ds1.SelectDistinct(MyStruct{}).ToSql()
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT "address", "email_address", "name" FROM "test"`)
 
 	type myStruct2 struct {
-		myStruct
+		MyStruct
 		Zipcode string `db:"zipcode"`
 	}
 
@@ -149,7 +149,7 @@ func (me *datasetTest) TestSelectDistinct() {
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT "address", "email_address", "name", "zipcode" FROM "test"`)
 
-	var myStructs []myStruct
+	var myStructs []MyStruct
 	sql, _, err = ds1.SelectDistinct(&myStructs).ToSql()
 	assert.NoError(t, err)
 	assert.Equal(t, sql, `SELECT DISTINCT "address", "email_address", "name" FROM "test"`)

--- a/dataset_update_test.go
+++ b/dataset_update_test.go
@@ -138,13 +138,13 @@ func (me *datasetTest) TestUpdateSqlWithValuerNull() {
 func (me *datasetTest) TestUpdateSqlWithEmbeddedStruct() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string    `db:"primary_phone"`
 		Home    string    `db:"home_phone"`
 		Created time.Time `db:"phone_created"`
 	}
 	type item struct {
-		phone
+		Phone
 		Address    string      `db:"address" goqu:"skipupdate"`
 		Name       string      `db:"name"`
 		Created    time.Time   `db:"created"`
@@ -152,7 +152,7 @@ func (me *datasetTest) TestUpdateSqlWithEmbeddedStruct() {
 	}
 	created, _ := time.Parse("2006-01-02", "2015-01-01")
 
-	sql, args, err := ds1.ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, phone: phone{
+	sql, args, err := ds1.ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, Phone: Phone{
 		Home:    "123123",
 		Primary: "456456",
 		Created: created,
@@ -165,20 +165,20 @@ func (me *datasetTest) TestUpdateSqlWithEmbeddedStruct() {
 func (me *datasetTest) TestUpdateSqlWithEmbeddedStructPtr() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string    `db:"primary_phone"`
 		Home    string    `db:"home_phone"`
 		Created time.Time `db:"phone_created"`
 	}
 	type item struct {
-		*phone
+		*Phone
 		Address string    `db:"address" goqu:"skipupdate"`
 		Name    string    `db:"name"`
 		Created time.Time `db:"created"`
 	}
 	created, _ := time.Parse("2006-01-02", "2015-01-01")
 
-	sql, args, err := ds1.ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, phone: &phone{
+	sql, args, err := ds1.ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, Phone: &Phone{
 		Home:    "123123",
 		Primary: "456456",
 		Created: created,
@@ -317,13 +317,13 @@ func (me *datasetTest) TestPreparedUpdateSqlWithSkipupdateTag() {
 func (me *datasetTest) TestPreparedUpdateSqlWithEmbeddedStruct() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string    `db:"primary_phone"`
 		Home    string    `db:"home_phone"`
 		Created time.Time `db:"phone_created"`
 	}
 	type item struct {
-		phone
+		Phone
 		Address    string      `db:"address" goqu:"skipupdate"`
 		Name       string      `db:"name"`
 		Created    time.Time   `db:"created"`
@@ -331,7 +331,7 @@ func (me *datasetTest) TestPreparedUpdateSqlWithEmbeddedStruct() {
 	}
 	created, _ := time.Parse("2006-01-02", "2015-01-01")
 
-	sql, args, err := ds1.Prepared(true).ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, phone: phone{
+	sql, args, err := ds1.Prepared(true).ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, Phone: Phone{
 		Home:    "123123",
 		Primary: "456456",
 		Created: created,
@@ -344,20 +344,20 @@ func (me *datasetTest) TestPreparedUpdateSqlWithEmbeddedStruct() {
 func (me *datasetTest) TestPreparedUpdateSqlWithEmbeddedStructPtr() {
 	t := me.T()
 	ds1 := From("items")
-	type phone struct {
+	type Phone struct {
 		Primary string    `db:"primary_phone"`
 		Home    string    `db:"home_phone"`
 		Created time.Time `db:"phone_created"`
 	}
 	type item struct {
-		*phone
+		*Phone
 		Address string    `db:"address" goqu:"skipupdate"`
 		Name    string    `db:"name"`
 		Created time.Time `db:"created"`
 	}
 	created, _ := time.Parse("2006-01-02", "2015-01-01")
 
-	sql, args, err := ds1.Prepared(true).ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, phone: &phone{
+	sql, args, err := ds1.Prepared(true).ToUpdateSql(item{Name: "Test", Address: "111 Test Addr", Created: created, Phone: &Phone{
 		Home:    "123123",
 		Primary: "456456",
 		Created: created,


### PR DESCRIPTION
Added ability for ScanStruct to allow embedded pointers with tests (added test for ScanStructs since it was missing)