### PR TITLE
Bugfix for chained Where()

### DIFF
--- a/dataset_select_test.go
+++ b/dataset_select_test.go
@@ -299,6 +299,31 @@ func (me *datasetTest) TestWhere() {
 	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" IN (SELECT "id" FROM "test2"))`)
 }
 
+func (me *datasetTest) TestWhereChain() {
+	t := me.T()
+	ds1 := From("test").Where(
+		I("x").Eq(0),
+		I("y").Eq(1),
+	)
+
+	ds2 := ds1.Where(
+		I("z").Eq(2),
+	)
+
+	a := ds2.Where(
+		I("a").Eq("A"),
+	)
+	b := ds2.Where(
+		I("b").Eq("B"),
+	)
+	sql, _, err := a.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE (("x" = 0) AND ("y" = 1) AND ("z" = 2) AND ("a" = 'A'))`)
+	sql, _, err = b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE (("x" = 0) AND ("y" = 1) AND ("z" = 2) AND ("b" = 'B'))`)
+}
+
 func (me *datasetTest) TestClearWhere() {
 	t := me.T()
 	ds1 := From("test")

--- a/expressions.go
+++ b/expressions.go
@@ -150,7 +150,8 @@ func (me expressionList) Expressions() []Expression {
 func (me expressionList) Append(expressions ...Expression) ExpressionList {
 	ret := new(expressionList)
 	ret.operator = me.operator
-	exps := me.expressions
+	exps := make([]Expression, len(me.expressions))
+	copy(exps, me.expressions)
 	for _, exp := range expressions {
 		exps = append(exps, exp)
 	}


### PR DESCRIPTION
Hello!
I'm using goqu with MySQL dialect.
Problem description: If you make detailed Dataset (using Where) from base Dataset, already having some where clauses, sometimes added expressions could be presented in the base dataset or its derivatives.

For example:
```
baseDS := From(...).Select(...).Where(<some heavy expressions with subqueries etc.>)
// some conditional filtering
if doFilter {
    baseDS = baseDS.Where(goqu.I("selected").Eq(1))
}
subDS1 := baseDS.Where(goqu.I("type").Eq("Type1"))
subDS2 := baseDS.Where(goqu.I("type").Eq("Type2")) //This may overwrite where clause for subDS1!

sql, _, err := subDS1.ToSql() // sql = SELECT ... ... WHERE ... ... AND "Type" = "Type2" ; should be "Type1"
...
```
This happens because of go append() behaviour - in expressionList.Append() it may return reallocated slice (and everything goes well) or slice at the same address (then shit could happens if another Dataset already using same physical memory to store its own expression). To prevent this you should always reallocate slice.
I have implemented this fix and added test case.
Alternatively you could build base Dataset for every subset, but this will produce excessive and hardly maintainable code. Also you can generate sql for one dataset at a time, but this won't work if you want to make Union or another combination.

Best regards,
Anton Kriukov.