### PR TITLE
Fixing broken tests due to changes to sqlmock

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -216,7 +216,7 @@ func (me *databaseTest) TestPrepare() {
 	t := me.T()
 	mDb, mock, err := sqlmock.New()
 	assert.NoError(t, err)
-	mock.ExpectPrepare("SELECT * FROM test WHERE id = ?")
+	mock.ExpectPrepare("SELECT \\* FROM test WHERE id = \\?")
 	db := New("mock", mDb)
 	stmt, err := db.Prepare("SELECT * FROM test WHERE id = ?")
 	assert.NoError(t, err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+services:
+  postgres:
+    image: postgres:9.6
+    environment:
+      - "POSTGRES_USER=postgres"
+      - "POSTGRES_DB=goqupostgres"
+    ports:
+      - "5432:5432"
+
+  mysql:
+    image: mysql:8.0
+    environment:
+      - "MYSQL_DATABASE=goqumysql"
+      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
+    ports:
+      - "3306:3306"


### PR DESCRIPTION
The tests are currently failing due to a change to sqlmock. `*/?` needed to be escaped due to it being a regex.

Probably worth vendoring dependencies. If you are cool with that I can submit another PR.