### PR TITLE
Support for defining WITH clauses for Common Table Expressions (CTE)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 services:
   - docker
 
+go_import_path: gopkg.in/doug-martin/goqu.v4
+
 env:
   - GO_VERSION="1.6"
   - GO_VERSION="1.7"

--- a/adapters.go
+++ b/adapters.go
@@ -85,10 +85,14 @@ type (
 		//
 		//buf: The current SqlBuilder to write the sql to
 		HavingSql(buf *SqlBuilder, having ExpressionList) error
-		//Generates the sql for COMPOUND expressions, sunch as UNION, and INTERSECT
+		//Generates the sql for COMPOUND expressions, such as UNION, and INTERSECT
 		//
 		//buf: The current SqlBuilder to write the sql to
 		CompoundsSql(buf *SqlBuilder, compounds []CompoundExpression) error
+		//Generates the sql for the WITH clauses for common table expressions (CTE)
+		//
+		//buf: The current SqlBuilder to write the sql to
+		CommonTablesSql(buf *SqlBuilder, ctes []CommonTableExpression) error
 		//Generates the sql for ORDER BY clause
 		//
 		//buf: The current SqlBuilder to write the sql to
@@ -161,18 +165,22 @@ type (
 		//
 		//buf: The current SqlBuilder to write the sql to
 		ExpressionListSql(buf *SqlBuilder, expressionList ExpressionList) error
-		//Generates SQL value for an SqlFunction
+		//Generates SQL value for a SqlFunction
 		//
 		//buf: The current SqlBuilder to write the sql to
 		SqlFunctionExpressionSql(buf *SqlBuilder, sqlFunc SqlFunctionExpression) error
-		//Generates SQL value for an CastExpression
+		//Generates SQL value for a CastExpression
 		//
 		//buf: The current SqlBuilder to write the sql to
 		CastExpressionSql(buf *SqlBuilder, casted CastExpression) error
-		//Generates SQL value for an CompoundExpression
+		//Generates SQL value for a CompoundExpression
 		//
 		//buf: The current SqlBuilder to write the sql to
 		CompoundExpressionSql(buf *SqlBuilder, compound CompoundExpression) error
+		//Generates SQL value for a CommonTableExpression
+		//
+		//buf: The current SqlBuilder to write the sql to
+		CommonTableExpressionSql(buf *SqlBuilder, commonTable CommonTableExpression) error
 		//Generates SQL value for a ColumnList
 		//
 		//buf: The current SqlBuilder to write the sql to
@@ -212,6 +220,10 @@ type (
 		OnConflictSql(buf *SqlBuilder, o ConflictExpression) error
 		//Returns true if the dialect supports a WHERE clause on upsert
 		SupportConflictUpdateWhere() bool
+		//Returns true if the dialect supports WITH common table expressions
+		SupportsWithCTE() bool
+		//Returns true if the dialect supports WITH RECURSIVE common table expressions
+		SupportsWithRecursiveCTE() bool
 	}
 )
 

--- a/adapters/mysql/dataset_adapter_test.go
+++ b/adapters/mysql/dataset_adapter_test.go
@@ -63,6 +63,13 @@ func (me *datasetAdapterTest) TestSupportsOrderByOnUpdate() {
 	assert.True(t, dsAdapter.SupportsLimitOnDelete())
 }
 
+func (me *datasetAdapterTest) TestSupportsWithCTE() {
+	t := me.T()
+	dsAdapter := me.GetDs("test").Adapter()
+	assert.False(t, dsAdapter.SupportsWithCTE())
+	assert.False(t, dsAdapter.SupportsWithRecursiveCTE())
+}
+
 func (me *datasetAdapterTest) TestIdentifiers() {
 	t := me.T()
 	ds := me.GetDs("test")

--- a/adapters/mysql/mysql.go
+++ b/adapters/mysql/mysql.go
@@ -86,6 +86,8 @@ func newDatasetAdapter(ds *goqu.Dataset) goqu.Adapter {
 	def.ConflictUpdateWhereSupported = false
 	def.InsertIgnoreSyntaxSupported = true
 	def.ConflictTargetSupported = false
+	def.WithCTESupported = false
+	def.WithCTERecursiveSupported = false
 	return &DatasetAdapter{def}
 }
 

--- a/dataset.go
+++ b/dataset.go
@@ -112,7 +112,12 @@ func From(table ...interface{}) *Dataset {
 	return ret.From(table...)
 }
 
-//Creates a WITH clause for a common table expression (CTE)
+//Creates a WITH clause for a common table expression (CTE).
+//
+//The name will be available to SELECT from in the associated query; and can optionally
+//contain a list of column names "name(col1, col2, col3)".
+//
+//The name will refer to the results of the specified subquery.
 func (me *Dataset) With(name string, subquery *Dataset) *Dataset {
 	ret := me.copy()
 	ret.clauses.CommonTables = append(ret.clauses.CommonTables, With(false, name, subquery))
@@ -120,6 +125,13 @@ func (me *Dataset) With(name string, subquery *Dataset) *Dataset {
 }
 
 //Creates a WITH RECURSIVE clause for a common table expression (CTE)
+//
+//The name will be available to SELECT from in the associated query; and must
+//contain a list of column names "name(col1, col2, col3)" for a recursive clause.
+//
+//The name will refer to the results of the specified subquery. The subquery for
+//a recursive query will always end with a UNION or UNION ALL with a clause that
+//refers to the CTE by name.
 func (me *Dataset) WithRecursive(name string, subquery *Dataset) *Dataset {
 	ret := me.copy()
 	ret.clauses.CommonTables = append(ret.clauses.CommonTables, With(true, name, subquery))

--- a/dataset_delete.go
+++ b/dataset_delete.go
@@ -24,6 +24,9 @@ func (me *Dataset) ToDeleteSql() (string, []interface{}, error) {
 	if !me.hasSources() {
 		return "", nil, NewGoquError("No source found when generating delete sql")
 	}
+	if err := me.adapter.CommonTablesSql(buf, me.clauses.CommonTables); err != nil {
+		return "", nil, err
+	}
 	if err := me.adapter.DeleteBeginSql(buf); err != nil {
 		return "", nil, err
 	}

--- a/dataset_insert.go
+++ b/dataset_insert.go
@@ -165,6 +165,9 @@ func (me *Dataset) getFieldsValues(value reflect.Value) (rowCols []interface{}, 
 //Creates an INSERT statement with the columns and values passed in
 func (me *Dataset) insertSql(cols ColumnList, values [][]interface{}, prepared bool, c ConflictExpression) (string, []interface{}, error) {
 	buf := NewSqlBuilder(prepared)
+	if err := me.adapter.CommonTablesSql(buf, me.clauses.CommonTables); err != nil {
+		return "", nil, err
+	}
 	if err := me.adapter.InsertBeginSql(buf, c); err != nil {
 		return "", nil, err
 	}
@@ -201,6 +204,9 @@ func (me *Dataset) insertSql(cols ColumnList, values [][]interface{}, prepared b
 //Creates an insert statement with values coming from another dataset
 func (me *Dataset) insertFromSql(other Dataset, prepared bool) (string, []interface{}, error) {
 	buf := NewSqlBuilder(prepared)
+	if err := me.adapter.CommonTablesSql(buf, me.clauses.CommonTables); err != nil {
+		return "", nil, err
+	}
 	if err := me.adapter.InsertBeginSql(buf, nil); err != nil {
 		return "", nil, err
 	}

--- a/dataset_select.go
+++ b/dataset_select.go
@@ -364,6 +364,9 @@ func (me *Dataset) ToSql() (string, []interface{}, error) {
 
 //Does actual sql generation of sql, accepts an sql builder so other methods can call when creating subselects and needing prepared sql.
 func (me *Dataset) selectSqlWriteTo(buf *SqlBuilder) error {
+	if err := me.adapter.CommonTablesSql(buf, me.clauses.CommonTables); err != nil {
+		return err
+	}
 	if me.clauses.SelectDistinct != nil {
 		if err := me.adapter.SelectDistinctSql(buf, me.clauses.SelectDistinct); err != nil {
 			return err

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -671,6 +671,34 @@ func (me *datasetTest) TestLiteralCastExpression() {
 	assert.Equal(t, buf.String(), `CAST("a" AS DATE)`)
 }
 
+func (me *datasetTest) TestCommonTableExpression() {
+	t := me.T()
+	buf := NewSqlBuilder(false)
+	ds := From("test")
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(false, "a", From("b"))))
+	assert.Equal(t, buf.String(), `a AS (SELECT * FROM "b")`)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(false, "a(x,y)", From("b"))))
+	assert.Equal(t, buf.String(), `a(x,y) AS (SELECT * FROM "b")`)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(true, "a", From("b"))))
+	assert.Equal(t, buf.String(), `a AS (SELECT * FROM "b")`)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(true, "a(x,y)", From("b"))))
+	assert.Equal(t, buf.String(), `a(x,y) AS (SELECT * FROM "b")`)
+
+	buf = NewSqlBuilder(true)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(false, "a", From("b"))))
+	assert.Equal(t, buf.args, []interface{}{})
+	assert.Equal(t, buf.String(), `a AS (SELECT * FROM "b")`)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(false, "a(x,y)", From("b"))))
+	assert.Equal(t, buf.args, []interface{}{})
+	assert.Equal(t, buf.String(), `a(x,y) AS (SELECT * FROM "b")`)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(true, "a", From("b"))))
+	assert.Equal(t, buf.args, []interface{}{})
+	assert.Equal(t, buf.String(), `a AS (SELECT * FROM "b")`)
+	assert.NoError(t, ds.Literal(me.Truncate(buf), With(true, "a(x,y)", From("b"))))
+	assert.Equal(t, buf.args, []interface{}{})
+	assert.Equal(t, buf.String(), `a(x,y) AS (SELECT * FROM "b")`)
+}
+
 func (me *datasetTest) TestCompoundExpression() {
 	t := me.T()
 	buf := NewSqlBuilder(false)

--- a/dataset_update.go
+++ b/dataset_update.go
@@ -33,6 +33,9 @@ func (me *Dataset) ToUpdateSql(update interface{}) (string, []interface{}, error
 		return "", nil, err
 	}
 	buf := NewSqlBuilder(me.isPrepared)
+	if err := me.adapter.CommonTablesSql(buf, me.clauses.CommonTables); err != nil {
+		return "", nil, err
+	}
 	if err := me.adapter.UpdateBeginSql(buf); err != nil {
 		return "", nil, err
 	}

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -226,7 +226,7 @@ func NewDefaultAdapter(ds *Dataset) Adapter {
 		DeleteClause:                 default_delete_clause,
 		TruncateClause:               default_truncate_clause,
 		WithFragment:                 default_with_fragment,
-		RecursiveFragment:	      default_recursive_fragment,
+		RecursiveFragment:            default_recursive_fragment,
 		CascadeFragment:              default_cascade_fragment,
 		RestrictFragment:             default_retrict_fragment,
 		DefaultValuesFragment:        default_default_values_fragment,

--- a/example_test.go
+++ b/example_test.go
@@ -563,6 +563,45 @@ func ExampleDataset_UnionAll() {
 	// SELECT * FROM (SELECT * FROM "test" LIMIT 1) AS "t1" UNION ALL (SELECT * FROM (SELECT * FROM "test2" ORDER BY "id" DESC) AS "t1")
 }
 
+func ExampleDataset_WithCTE() {
+	db := goqu.New("default", driver)
+	sql, _, _ := db.From("one").
+		With("one", db.From().Select(goqu.L("1"))).
+		Select(goqu.Star()).
+		ToSql()
+	fmt.Println(sql)
+	sql, _, _ = db.From("derived").
+		With("intermed", db.From("test").Select(goqu.Star()).Where(goqu.I("x").Gte(5))).
+		With("derived", db.From("intermed").Select(goqu.Star()).Where(goqu.I("x").Lt(10))).
+		Select(goqu.Star()).
+		ToSql()
+	fmt.Println(sql)
+	sql, _, _ = db.From("multi").
+		With("multi(x,y)", db.From().Select(goqu.L("1"), goqu.L("2"))).
+		Select(goqu.I("x"), goqu.I("y")).
+		ToSql()
+	fmt.Println(sql)
+	// Output:
+	// WITH one AS (SELECT 1) SELECT * FROM "one"
+	// WITH intermed AS (SELECT * FROM "test" WHERE ("x" >= 5)), derived AS (SELECT * FROM "intermed" WHERE ("x" < 10)) SELECT * FROM "derived"
+	// WITH multi(x,y) AS (SELECT 1, 2) SELECT "x", "y" FROM "multi"
+}
+
+// TODO: func ExampleDataset_WithCTEInsert/Update/Delete
+
+func ExampleDataset_WithCTERecursive() {
+	db := goqu.New("default", driver)
+	sql, _, _ := db.From("nums").
+		WithRecursive("nums(x)",
+			db.From().Select(goqu.L("1")).
+			UnionAll(db.From("nums").
+				Select(goqu.L("x+1")).Where(goqu.I("x").Lt(5)))).
+		ToSql()
+	fmt.Println(sql)
+	// Output:
+	// WITH RECURSIVE nums(x) AS (SELECT 1 UNION ALL (SELECT x+1 FROM "nums" WHERE ("x" < 5))) SELECT * FROM "nums"
+}
+
 func ExampleDataset_Intersect() {
 	db := goqu.New("default", driver)
 	sql, _, _ := db.From("test").

--- a/expressions.go
+++ b/expressions.go
@@ -1427,6 +1427,37 @@ func (me compound) Type() compoundType { return me.t }
 func (me compound) Rhs() SqlExpression { return me.rhs }
 
 type (
+	CommonTableExpression interface {
+		Expression
+		IsRecursive() bool
+		//Returns the alias name for the extracted expression
+		Name() LiteralExpression
+		//Returns the Expression being extracted
+		SubQuery() SqlExpression
+	}
+	commonExpr struct {
+		recursive bool
+		name      LiteralExpression
+		subQuery  SqlExpression
+	}
+)
+
+//Creates a new WITH common table expression for a SqlExpression, typically Datasets'. This function is used internally by Dataset when a CTE is added to another Dataset
+func With(recursive bool, name string, subQuery SqlExpression) CommonTableExpression {
+	return commonExpr{recursive: recursive, name: Literal(name), subQuery: subQuery}
+}
+
+func (me commonExpr) Expression() Expression { return me }
+
+func (me commonExpr) Clone() Expression {
+	return commonExpr{recursive: me.recursive, name: me.name, subQuery:me.subQuery.Clone().(SqlExpression)}
+}
+
+func (me commonExpr) IsRecursive() bool { return me.recursive }
+func (me commonExpr) Name() LiteralExpression { return me.name }
+func (me commonExpr) SubQuery() SqlExpression { return me.subQuery }
+
+type (
 	//An Expression that the ON CONFLICT/ON DUPLICATE KEY portion of an INSERT statement
 	ConflictExpression interface {
 		Updates() *ConflictUpdate


### PR DESCRIPTION
Thanks for this great library; I've found it very useful and filled my needs for query generation. Just found one missing element that did exist in some of the other major query generators which is support for Common Table Expressions (CTEs), i.e. WITH clauses. This includes both WITH and WITH RECURSIVE versions and applies them to SELECT, UPDATE, DELETE and INSERT queries (although I am just using them in the SELECT context).

These are a useful way to build efficient queries by re-using commonly used subparts. They are supported in PostgreSQL (https://www.postgresql.org/docs/current/static/queries-with.html) and SQLite (https://sqlite.org/lang_with.html); and I noticed in the upcoming MySQL 8.0 currently in Beta (https://dev.mysql.com/doc/refman/8.0/en/with.html). I'm using PostgreSQL.

Would appreciate your feedback on the way I have added the WITH clauses to goqu; as well as appropriate level of test and documentation. I aimed for a similar level as for the Union and related clauses.