### PR TITLE
Check for nil using reflection.

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -204,7 +204,7 @@ func (me *Dataset) hasSources() bool {
 //Errors:
 //   * If there is an error generating the SQL
 func (me *Dataset) Literal(buf *SqlBuilder, val interface{}) error {
-	if val == nil {
+	if val == nil || reflect.ValueOf(val).IsNil() {
 		return me.adapter.LiteralNil(buf)
 	}
 	if v, ok := val.(Expression); ok {


### PR DESCRIPTION
I won't have time to set up my environment for running the tests, but I'm submitting this PR to point you to the area where the bug is I found. I wouldn't suggest using the reflection fix that I sent in, but it solves the issue. I think a nil check inside the type assertion block on line 230 of dataset.go  would suffice, but there could be other cases where this issue occurs. Here's a go playground demonstrating the general issue:

https://play.golang.org/p/KIuECqRloT