### PR TITLE
Add support for "FOR UPDATE" and "SKIP LOCKED"

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -105,6 +105,10 @@ type (
 		//
 		//buf: The current SqlBuilder to write the sql to
 		OffsetSql(buf *SqlBuilder, offset uint) error
+		//Generates the sql for FOR clause
+		//
+		//buf: The current SqlBuilder to write the sql to
+		ForSql(buf *SqlBuilder, lockingClause Lock) error
 		//Generates the sql for another Dataset being used as a sub select.
 		//
 		//buf: The current SqlBuilder to write the sql to

--- a/dataset.go
+++ b/dataset.go
@@ -32,6 +32,7 @@ type (
 		Offset         uint
 		Returning      ColumnList
 		Compounds      []CompoundExpression
+		Lock           Lock
 	}
 	//A Dataset is used to build up an SQL statement, each method returns a copy of the current Dataset with options added to it.
 	//Once done building up your Dataset you can either call an action method on it to execute the statement or use one of the SQL generation methods.

--- a/dataset_select.go
+++ b/dataset_select.go
@@ -220,6 +220,36 @@ func (me *Dataset) ForUpdate(waitOption WaitOption) *Dataset {
 	return ret
 }
 
+//Adds a FOR NO KEY UPDATE clause. See examples.
+func (me *Dataset) ForNoKeyUpdate(waitOption WaitOption) *Dataset {
+	ret := me.copy()
+	ret.clauses.Lock = Lock{
+		Strength:   FOR_NO_KEY_UPDATE,
+		WaitOption: waitOption,
+	}
+	return ret
+}
+
+//Adds a FOR Key SHARE clause. See examples.
+func (me *Dataset) ForKeyShare(waitOption WaitOption) *Dataset {
+	ret := me.copy()
+	ret.clauses.Lock = Lock{
+		Strength:   FOR_SHARE,
+		WaitOption: waitOption,
+	}
+	return ret
+}
+
+//Adds a FOR SHARE clause. See examples.
+func (me *Dataset) ForShare(waitOption WaitOption) *Dataset {
+	ret := me.copy()
+	ret.clauses.Lock = Lock{
+		Strength:   FOR_SHARE,
+		WaitOption: waitOption,
+	}
+	return ret
+}
+
 //Adds a GROUP BY clause. See examples.
 func (me *Dataset) GroupBy(groupBy ...interface{}) *Dataset {
 	ret := me.copy()

--- a/dataset_select.go
+++ b/dataset_select.go
@@ -230,11 +230,11 @@ func (me *Dataset) ForNoKeyUpdate(waitOption WaitOption) *Dataset {
 	return ret
 }
 
-//Adds a FOR Key SHARE clause. See examples.
+//Adds a FOR KEY SHARE clause. See examples.
 func (me *Dataset) ForKeyShare(waitOption WaitOption) *Dataset {
 	ret := me.copy()
 	ret.clauses.Lock = Lock{
-		Strength:   FOR_SHARE,
+		Strength:   FOR_KEY_SHARE,
 		WaitOption: waitOption,
 	}
 	return ret

--- a/dataset_select.go
+++ b/dataset_select.go
@@ -210,6 +210,16 @@ func (me *Dataset) ClearWhere() *Dataset {
 	return ret
 }
 
+//Adds a FOR UPDATE clause. See examples.
+func (me *Dataset) ForUpdate(waitOption WaitOption) *Dataset {
+	ret := me.copy()
+	ret.clauses.Lock = Lock{
+		Strength:   FOR_UPDATE,
+		WaitOption: waitOption,
+	}
+	return ret
+}
+
 //Adds a GROUP BY clause. See examples.
 func (me *Dataset) GroupBy(groupBy ...interface{}) *Dataset {
 	ret := me.copy()
@@ -400,6 +410,8 @@ func (me *Dataset) selectSqlWriteTo(buf *SqlBuilder) error {
 	if err := me.adapter.LimitSql(buf, me.clauses.Limit); err != nil {
 		return err
 	}
-	return me.adapter.OffsetSql(buf, me.clauses.Offset)
-
+	if err := me.adapter.OffsetSql(buf, me.clauses.Offset); err != nil {
+		return err
+	}
+	return me.adapter.ForSql(buf, me.clauses.Lock)
 }

--- a/dataset_select_test.go
+++ b/dataset_select_test.go
@@ -424,6 +424,82 @@ func (me *datasetTest) TestClearOffset() {
 	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1)`)
 }
 
+func (me *datasetTest) TestForUpdate() {
+	t := me.T()
+	ds1 := From("test")
+
+	b := ds1.Where(
+		I("a").Gt(1),
+	).ForUpdate(WAIT)
+	sql, _, err := b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR UPDATE `)
+
+	b = ds1.Where(
+		I("a").Gt(1),
+	).ForUpdate(SKIP_LOCKED)
+	sql, _, err = b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR UPDATE SKIP LOCKED`)
+}
+
+func (me *datasetTest) TestForNoKeyUpdate() {
+	t := me.T()
+	ds1 := From("test")
+
+	b := ds1.Where(
+		I("a").Gt(1),
+	).ForNoKeyUpdate(WAIT)
+	sql, _, err := b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR NO KEY UPDATE `)
+
+	b = ds1.Where(
+		I("a").Gt(1),
+	).ForNoKeyUpdate(SKIP_LOCKED)
+	sql, _, err = b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR NO KEY UPDATE SKIP LOCKED`)
+}
+
+func (me *datasetTest) TestForKeyShare() {
+	t := me.T()
+	ds1 := From("test")
+
+	b := ds1.Where(
+		I("a").Gt(1),
+	).ForKeyShare(WAIT)
+	sql, _, err := b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR KEY SHARE `)
+
+	b = ds1.Where(
+		I("a").Gt(1),
+	).ForKeyShare(SKIP_LOCKED)
+	sql, _, err = b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR KEY SHARE SKIP LOCKED`)
+}
+
+func (me *datasetTest) TestForShare() {
+	t := me.T()
+	ds1 := From("test")
+
+	b := ds1.Where(
+		I("a").Gt(1),
+	).ForShare(WAIT)
+	sql, _, err := b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR SHARE `)
+
+	b = ds1.Where(
+		I("a").Gt(1),
+	).ForShare(SKIP_LOCKED)
+	sql, _, err = b.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `SELECT * FROM "test" WHERE ("a" > 1) FOR SHARE SKIP LOCKED`)
+}
+
 func (me *datasetTest) TestGroupBy() {
 	t := me.T()
 	ds1 := From("test")

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -48,8 +48,8 @@ var (
 	default_for_no_key_update_fragment = []byte(" FOR NO KEY UPDATE ")
 	default_for_share_fragment         = []byte(" FOR SHARE ")
 	default_for_key_share_fragment     = []byte(" FOR KEY SHARE ")
-	default_nowait_fragment            = []byte("NOWAIT ")
-	default_skip_locked_fragment       = []byte("SKIP LOCKED ")
+	default_nowait_fragment            = []byte("NOWAIT")
+	default_skip_locked_fragment       = []byte("SKIP LOCKED")
 	default_as_fragment                = []byte(" AS ")
 	default_asc_fragment               = []byte(" ASC")
 	default_desc_fragment              = []byte(" DESC")
@@ -169,9 +169,9 @@ type (
 		ForShareFragment []byte
 		// The SQL FOR KEY SHARE fragment(DEFAULT=[]byte(" FOR KEY SHARE "))
 		ForKeyShareFragment []byte
-		// The SQL NOWAIT fragment(DEFAULT=[]byte("NOWAIT "))
+		// The SQL NOWAIT fragment(DEFAULT=[]byte("NOWAIT"))
 		NowaitFragment []byte
-		// The SQL SKIP LOCKED fragment(DEFAULT=[]byte("SKIP LOCKED "))
+		// The SQL SKIP LOCKED fragment(DEFAULT=[]byte("SKIP LOCKED"))
 		SkipLockedFragment []byte
 		//The SQL AS fragment when aliasing an Expression(DEFAULT=[]byte(" AS "))
 		AsFragment []byte

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -10,55 +10,61 @@ import (
 )
 
 var (
-	replacement_rune                = '?'
-	comma_rune                      = ','
-	space_rune                      = ' '
-	left_paren_rune                 = '('
-	right_paren_rune                = ')'
-	star_rune                       = '*'
-	default_quote                   = '"'
-	period_rune                     = '.'
-	empty_string                    = ""
-	default_null                    = []byte("NULL")
-	default_true                    = []byte("TRUE")
-	default_false                   = []byte("FALSE")
-	default_update_clause           = []byte("UPDATE")
-	default_insert_clause           = []byte("INSERT INTO")
-	default_select_clause           = []byte("SELECT")
-	default_delete_clause           = []byte("DELETE")
-	default_truncate_clause         = []byte("TRUNCATE")
-	default_with_fragment           = []byte("WITH ")
-	default_recursive_fragment      = []byte("RECURSIVE ")
-	default_cascade_fragment        = []byte(" CASCADE")
-	default_retrict_fragment        = []byte(" RESTRICT")
-	default_default_values_fragment = []byte(" DEFAULT VALUES")
-	default_values_fragment         = []byte(" VALUES ")
-	default_identity_fragment       = []byte(" IDENTITY")
-	default_set_fragment            = []byte(" SET ")
-	default_distinct_fragment       = []byte(" DISTINCT ")
-	default_returning_fragment      = []byte(" RETURNING ")
-	default_from_fragment           = []byte(" FROM")
-	default_where_fragment          = []byte(" WHERE ")
-	default_group_by_fragment       = []byte(" GROUP BY ")
-	default_having_fragment         = []byte(" HAVING ")
-	default_order_by_fragment       = []byte(" ORDER BY ")
-	default_limit_fragment          = []byte(" LIMIT ")
-	default_offset_fragment         = []byte(" OFFSET ")
-	default_as_fragment             = []byte(" AS ")
-	default_asc_fragment            = []byte(" ASC")
-	default_desc_fragment           = []byte(" DESC")
-	default_nulls_first_fragment    = []byte(" NULLS FIRST")
-	default_nulls_last_fragment     = []byte(" NULLS LAST")
-	default_and_fragment            = []byte(" AND ")
-	default_or_fragment             = []byte(" OR ")
-	default_union_fragment          = []byte(" UNION ")
-	default_union_all_fragment      = []byte(" UNION ALL ")
-	default_intersect_fragment      = []byte(" INTERSECT ")
-	default_intersect_all_fragment  = []byte(" INTERSECT ALL ")
-	default_set_operator_rune       = '='
-	default_string_quote_rune       = '\''
-	default_place_holder_rune       = '?'
-	default_operator_lookup         = map[BooleanOperation][]byte{
+	replacement_rune                   = '?'
+	comma_rune                         = ','
+	space_rune                         = ' '
+	left_paren_rune                    = '('
+	right_paren_rune                   = ')'
+	star_rune                          = '*'
+	default_quote                      = '"'
+	period_rune                        = '.'
+	empty_string                       = ""
+	default_null                       = []byte("NULL")
+	default_true                       = []byte("TRUE")
+	default_false                      = []byte("FALSE")
+	default_update_clause              = []byte("UPDATE")
+	default_insert_clause              = []byte("INSERT INTO")
+	default_select_clause              = []byte("SELECT")
+	default_delete_clause              = []byte("DELETE")
+	default_truncate_clause            = []byte("TRUNCATE")
+	default_with_fragment              = []byte("WITH ")
+	default_recursive_fragment         = []byte("RECURSIVE ")
+	default_cascade_fragment           = []byte(" CASCADE")
+	default_retrict_fragment           = []byte(" RESTRICT")
+	default_default_values_fragment    = []byte(" DEFAULT VALUES")
+	default_values_fragment            = []byte(" VALUES ")
+	default_identity_fragment          = []byte(" IDENTITY")
+	default_set_fragment               = []byte(" SET ")
+	default_distinct_fragment          = []byte(" DISTINCT ")
+	default_returning_fragment         = []byte(" RETURNING ")
+	default_from_fragment              = []byte(" FROM")
+	default_where_fragment             = []byte(" WHERE ")
+	default_group_by_fragment          = []byte(" GROUP BY ")
+	default_having_fragment            = []byte(" HAVING ")
+	default_order_by_fragment          = []byte(" ORDER BY ")
+	default_limit_fragment             = []byte(" LIMIT ")
+	default_offset_fragment            = []byte(" OFFSET ")
+	default_for_update_fragment        = []byte(" FOR UPDATE ")
+	default_for_no_key_update_fragment = []byte(" FOR NO KEY UPDATE ")
+	default_for_share_fragment         = []byte(" FOR SHARE ")
+	default_for_key_share_fragment     = []byte(" FOR KEY SHARE ")
+	default_nowait_fragment            = []byte("NOWAIT ")
+	default_skip_locked_fragment       = []byte("SKIP LOCKED ")
+	default_as_fragment                = []byte(" AS ")
+	default_asc_fragment               = []byte(" ASC")
+	default_desc_fragment              = []byte(" DESC")
+	default_nulls_first_fragment       = []byte(" NULLS FIRST")
+	default_nulls_last_fragment        = []byte(" NULLS LAST")
+	default_and_fragment               = []byte(" AND ")
+	default_or_fragment                = []byte(" OR ")
+	default_union_fragment             = []byte(" UNION ")
+	default_union_all_fragment         = []byte(" UNION ALL ")
+	default_intersect_fragment         = []byte(" INTERSECT ")
+	default_intersect_all_fragment     = []byte(" INTERSECT ALL ")
+	default_set_operator_rune          = '='
+	default_string_quote_rune          = '\''
+	default_place_holder_rune          = '?'
+	default_operator_lookup            = map[BooleanOperation][]byte{
 		EQ_OP:                []byte("="),
 		NEQ_OP:               []byte("!="),
 		GT_OP:                []byte(">"),
@@ -155,6 +161,18 @@ type (
 		LimitFragment []byte
 		//The SQL OFFSET BY clause fragment(DEFAULT=[]byte(" OFFSET "))
 		OffsetFragment []byte
+		// The SQL FOR UPDATE fragment(DEFAULT=[]byte(" FOR UPDATE "))
+		ForUpdateFragment []byte
+		// The SQL FOR NO KEY UPDATE fragment(DEFAULT=[]byte(" FOR NO KEY UPDATE "))
+		ForNoKeyUpdateFragment []byte
+		// The SQL FOR SHARE fragment(DEFAULT=[]byte(" FOR SHARE "))
+		ForShareFragment []byte
+		// The SQL FOR KEY SHARE fragment(DEFAULT=[]byte(" FOR KEY SHARE "))
+		ForKeyShareFragment []byte
+		// The SQL NOWAIT fragment(DEFAULT=[]byte("NOWAIT "))
+		NowaitFragment []byte
+		// The SQL SKIP LOCKED fragment(DEFAULT=[]byte("SKIP LOCKED "))
+		SkipLockedFragment []byte
 		//The SQL AS fragment when aliasing an Expression(DEFAULT=[]byte(" AS "))
 		AsFragment []byte
 		//The quote rune to use when quoting identifiers(DEFAULT='"')
@@ -242,6 +260,12 @@ func NewDefaultAdapter(ds *Dataset) Adapter {
 		OrderByFragment:              default_order_by_fragment,
 		LimitFragment:                default_limit_fragment,
 		OffsetFragment:               default_offset_fragment,
+		ForUpdateFragment:            default_for_update_fragment,
+		ForNoKeyUpdateFragment:       default_for_no_key_update_fragment,
+		ForShareFragment:             default_for_share_fragment,
+		ForKeyShareFragment:          default_for_key_share_fragment,
+		NowaitFragment:               default_nowait_fragment,
+		SkipLockedFragment:           default_skip_locked_fragment,
 		AsFragment:                   default_as_fragment,
 		QuoteRune:                    default_quote,
 		Null:                         default_null,
@@ -664,6 +688,29 @@ func (me *DefaultAdapter) OffsetSql(buf *SqlBuilder, offset uint) error {
 	if offset > 0 {
 		buf.Write(me.OffsetFragment)
 		return me.Literal(buf, offset)
+	}
+	return nil
+}
+
+//Generates the FOR (aka "locking") clause for an SQL statement
+func (me *DefaultAdapter) ForSql(buf *SqlBuilder, lockingClause Lock) error {
+	switch lockingClause.Strength {
+	case FOR_NOLOCK:
+		return nil
+	case FOR_UPDATE:
+		buf.Write(me.ForUpdateFragment)
+	case FOR_NO_KEY_UPDATE:
+		buf.Write(me.ForNoKeyUpdateFragment)
+	case FOR_SHARE:
+		buf.Write(me.ForShareFragment)
+	case FOR_KEY_SHARE:
+		buf.Write(me.ForKeyShareFragment)
+	}
+	switch lockingClause.WaitOption {
+	case NOWAIT:
+		buf.Write(me.NowaitFragment)
+	case SKIP_LOCKED:
+		buf.Write(me.SkipLockedFragment)
 	}
 	return nil
 }

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -706,6 +706,8 @@ func (me *DefaultAdapter) ForSql(buf *SqlBuilder, lockingClause Lock) error {
 	case FOR_KEY_SHARE:
 		buf.Write(me.ForKeyShareFragment)
 	}
+	// the WAIT case is the default in Postgres, and is what you get if you don't specify NOWAIT or
+	// SKIP LOCKED.  There's no special syntax for it in PG, so we don't do anything for it here
 	switch lockingClause.WaitOption {
 	case NOWAIT:
 		buf.Write(me.NowaitFragment)

--- a/expressions.go
+++ b/expressions.go
@@ -300,6 +300,27 @@ func (me columnList) Append(cols ...Expression) ColumnList {
 }
 
 type (
+	LockStrength int
+	WaitOption   int
+	Lock         struct {
+		Strength   LockStrength
+		WaitOption WaitOption
+	}
+)
+
+const (
+	FOR_NOLOCK LockStrength = iota
+	FOR_UPDATE
+	FOR_NO_KEY_UPDATE
+	FOR_SHARE
+	FOR_KEY_SHARE
+
+	WAIT WaitOption = iota
+	NOWAIT
+	SKIP_LOCKED
+)
+
+type (
 	JoinType      int
 	JoinCondition int
 	//Parent type for join expressions
@@ -1450,10 +1471,10 @@ func With(recursive bool, name string, subQuery SqlExpression) CommonTableExpres
 func (me commonExpr) Expression() Expression { return me }
 
 func (me commonExpr) Clone() Expression {
-	return commonExpr{recursive: me.recursive, name: me.name, subQuery:me.subQuery.Clone().(SqlExpression)}
+	return commonExpr{recursive: me.recursive, name: me.name, subQuery: me.subQuery.Clone().(SqlExpression)}
 }
 
-func (me commonExpr) IsRecursive() bool { return me.recursive }
+func (me commonExpr) IsRecursive() bool       { return me.recursive }
 func (me commonExpr) Name() LiteralExpression { return me.name }
 func (me commonExpr) SubQuery() SqlExpression { return me.subQuery }
 


### PR DESCRIPTION
This addresses #43.  It's a first stab, but hopefully close.

The public interface only exposes a .ForUpdate() method on the dataset for now, but under the hood it's built to support .ForNoKeyUpdate(), .ForShare(), and .ForKeyShare() as well.