### PR TITLE
v5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 services:
   - docker
 
-go_import_path: gopkg.in/doug-martin/goqu.v4
+go_import_path: gopkg.in/doug-martin/goqu.v5
 
 env:
   - GO_VERSION="1.8"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## v5.0.0
+
+* Drop go 1.6 support, supported versions are `1.8`, `1.9` and latest
+* Add context support [#64](https://github.com/doug-martin/goqu/pull/64) - [@cmoad](https://github.com/cmoad)
+
 ## v4.2.0
 
 * Add support for ON CONFLICT when using a dataset [#55](https://github.com/doug-martin/goqu/pull/55) - [@bobrnor](https://github.com/bobrnor)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ or hooks I would recommend looking at some of the great ORM libraries such as:
 ## Installation
 
 ```sh
-go get -u gopkg.in/doug-martin/goqu.v4
+go get -u gopkg.in/doug-martin/goqu.v5
 ```
 
 
@@ -63,17 +63,17 @@ go get -u gopkg.in/doug-martin/goqu.v4
 
 In order to start using goqu with your database you need to load an adapter. We have included some adapters by default.
 
-1. Postgres - `import "gopkg.in/doug-martin/goqu.v4/adapters/postgres"`
-2. MySQL - `import "gopkg.in/doug-martin/goqu.v4/adapters/mysql"`
-3. SQLite3 - `import "gopkg.in/doug-martin/goqu.v4/adapters/sqlite3"`
+1. Postgres - `import "gopkg.in/doug-martin/goqu.v5/adapters/postgres"`
+2. MySQL - `import "gopkg.in/doug-martin/goqu.v5/adapters/mysql"`
+3. SQLite3 - `import "gopkg.in/doug-martin/goqu.v5/adapters/sqlite3"`
 
 Adapters in goqu work the same way as a driver with the database in that they register themselves with goqu once loaded.
 
 ```go
 import (
   "database/sql"
-  "gopkg.in/doug-martin/goqu.v4"
-  _ "gopkg.in/doug-martin/goqu.v4/adapters/postgres"
+  "gopkg.in/doug-martin/goqu.v5"
+  _ "gopkg.in/doug-martin/goqu.v5/adapters/postgres"
   _ "github.com/lib/pq"
 )
 ```
@@ -709,7 +709,7 @@ For example the code for the postgres adapter is fairly short.
 package postgres
 
 import (
-    "gopkg.in/doug-martin/goqu.v4"
+    "gopkg.in/doug-martin/goqu.v5"
 )
 
 //postgres requires a $ placeholder for prepared statements

--- a/adapters/mysql/dataset_adapter_test.go
+++ b/adapters/mysql/dataset_adapter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/c2fo/testify/assert"
 	"github.com/c2fo/testify/suite"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 type datasetAdapterTest struct {

--- a/adapters/mysql/mysql.go
+++ b/adapters/mysql/mysql.go
@@ -1,6 +1,6 @@
 package mysql
 
-import "gopkg.in/doug-martin/goqu.v4"
+import "gopkg.in/doug-martin/goqu.v5"
 
 var (
 	placeholder_rune    = '?'

--- a/adapters/mysql/mysql_test.go
+++ b/adapters/mysql/mysql_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/c2fo/testify/assert"
 	"github.com/c2fo/testify/suite"
 	_ "github.com/go-sql-driver/mysql"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 const (

--- a/adapters/postgres/dataset_adapter_test.go
+++ b/adapters/postgres/dataset_adapter_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/c2fo/testify/suite"
 	"github.com/c2fo/testify/assert"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 type datasetAdapterTest struct {

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1,7 +1,7 @@
 package postgres
 
 import (
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 const placeholder_rune = '$'

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/c2fo/testify/assert"
 	"github.com/c2fo/testify/suite"
 	"github.com/lib/pq"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 const schema = `

--- a/adapters/sqlite3/dataset_adapter_test.go
+++ b/adapters/sqlite3/dataset_adapter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/c2fo/testify/assert"
 	"github.com/c2fo/testify/suite"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 type datasetAdapterTest struct {

--- a/adapters/sqlite3/sqlite3.go
+++ b/adapters/sqlite3/sqlite3.go
@@ -1,6 +1,6 @@
 package sqlite3
 
-import "gopkg.in/doug-martin/goqu.v4"
+import "gopkg.in/doug-martin/goqu.v5"
 
 var (
 	placeholder_rune    = '?'

--- a/adapters/sqlite3/sqlite3_test.go
+++ b/adapters/sqlite3/sqlite3_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/c2fo/testify/assert"
 	"github.com/c2fo/testify/suite"
 	_ "github.com/mattn/go-sqlite3"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 const (

--- a/database.go
+++ b/database.go
@@ -43,8 +43,8 @@ type (
 //      import (
 //          "database/sql"
 //          "fmt"
-//          "gopkg.in/doug-martin/goqu.v4"
-//          _ "gopkg.in/doug-martin/goqu.v4/adapters/postgres"
+//          "gopkg.in/doug-martin/goqu.v5"
+//          _ "gopkg.in/doug-martin/goqu.v5/adapters/postgres"
 //          _ "github.com/lib/pq"
 //      )
 //

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ services:
   goqu:
     image: "golang:${GO_VERSION}"
     command: bash -c "sleep 30 && go test -v -race ./..."
-    working_dir: /go/src/gopkg.in/doug-martin/goqu.v4
+    working_dir: /go/src/gopkg.in/doug-martin/goqu.v5
     volumes:
-      - "./:/go/src/gopkg.in/doug-martin/goqu.v4"
+      - "./:/go/src/gopkg.in/doug-martin/goqu.v5"
     environment:
       MYSQL_URI: 'root@tcp(mysql:3306)/goqumysql?parseTime=true'
       PG_URI: 'postgres://postgres:@postgres:5432/goqupostgres?sslmode=disable'
@@ -32,9 +32,9 @@ services:
   goqu-coverage:
     image: "golang:${GO_VERSION}"
     command: bash -c "sleep 30 && ./go.test.sh"
-    working_dir: /go/src/gopkg.in/doug-martin/goqu.v4
+    working_dir: /go/src/gopkg.in/doug-martin/goqu.v5
     volumes:
-      - "./:/go/src/gopkg.in/doug-martin/goqu.v4"
+      - "./:/go/src/gopkg.in/doug-martin/goqu.v5"
     environment:
       MYSQL_URI: 'root@tcp(mysql:3306)/goqumysql?parseTime=true'
       PG_URI: 'postgres://postgres:@postgres:5432/goqupostgres?sslmode=disable'

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
-	"gopkg.in/doug-martin/goqu.v4"
+	"gopkg.in/doug-martin/goqu.v5"
 )
 
 var driver *sql.DB


### PR DESCRIPTION
# v5.0.0
 * Drop go 1.6 support, supported versions are `1.8`, `1.9` and latest
* Add context support [#64](https://github.com/doug-martin/goqu/pull/64) - [@cmoad](https://github.com/cmoad)