### PR TITLE
Postgres arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,27 @@ if !found {
 }
 ```
 
+
+**NOTE** Using the `goqu.SetColumnRenameFunction` function, you can change the function that's used to rename struct fields when struct tags aren't defined
+
+```go
+import "strings"
+
+goqu.SetColumnRenameFunction(strings.ToUpper)
+
+type User struct{
+  FirstName string
+  LastName string
+}
+
+var user User
+//SELECT "FIRSTNAME", "LASTNAME" FROM "user" LIMIT 1;
+found, err := db.From("user").ScanStruct(&user)
+// ...
+```
+
+
+
 * [`ScanVals`](http://godoc.org/github.com/doug-martin/goqu#Dataset.ScanVals) - scans a rows of 1 column into a slice of primitive values
 ```go
 var ids []int64

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -14,9 +14,15 @@ type DatasetAdapter struct {
 	*goqu.DefaultAdapter
 }
 
-//Generates SQL for a slice of values (e.g. []int64{1,2,3,4} -> (1,2,3,4)
+//Generates SQL for a slice of values (e.g. []int64{1,2,3,4} -> ARRAY[1,2,3,4] or '{}' if empty
 func (me *DatasetAdapter) SliceValueSql(buf *goqu.SqlBuilder, slice reflect.Value) error {
-	buf.WriteString("ARRAY[")
+	sliceEmpty := slice.Len() == 0
+
+	if sliceEmpty {
+		buf.WriteString("'{")
+	} else {
+		buf.WriteString("ARRAY[")
+	}
 
 	for i, l := 0, slice.Len(); i < l; i++ {
 		if err := me.Literal(buf, slice.Index(i).Interface()); err != nil {
@@ -27,7 +33,12 @@ func (me *DatasetAdapter) SliceValueSql(buf *goqu.SqlBuilder, slice reflect.Valu
 			buf.WriteRune(space_rune)
 		}
 	}
-	buf.WriteRune(']')
+
+	if sliceEmpty {
+		buf.WriteString("}'")
+	} else {
+		buf.WriteRune(']')
+	}
 	return nil
 }
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -2,7 +2,8 @@ package postgres
 
 import (
 	"reflect"
-	"gopkg.in/doug-martin/goqu.v5"
+	// "gopkg.in/doug-martin/goqu.v5"
+	"github.com/blainehansen/goqu"
 )
 
 const placeholder_rune = '$'

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -11,7 +11,7 @@ type DatasetAdapter struct {
 }
 
 //Generates SQL for a slice of values (e.g. []int64{1,2,3,4} -> (1,2,3,4)
-func (me *DatasetAdapter) SliceValueSql(buf *SqlBuilder, slice reflect.Value) error {
+func (me *DatasetAdapter) SliceValueSql(buf *goqu.SqlBuilder, slice reflect.Value) error {
 	buf.WriteString("ARRAY[")
 
 	for i, l := 0, slice.Len(); i < l; i++ {

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1,10 +1,13 @@
 package postgres
 
 import (
+	"reflect"
 	"gopkg.in/doug-martin/goqu.v5"
 )
 
 const placeholder_rune = '$'
+const comma_rune = ','
+const space_rune = ' '
 
 type DatasetAdapter struct {
 	*goqu.DefaultAdapter

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -6,12 +6,34 @@ import (
 
 const placeholder_rune = '$'
 
+type DatasetAdapter struct {
+	*goqu.DefaultAdapter
+}
+
+//Generates SQL for a slice of values (e.g. []int64{1,2,3,4} -> (1,2,3,4)
+func (me *DatasetAdapter) SliceValueSql(buf *SqlBuilder, slice reflect.Value) error {
+	buf.WriteString("ARRAY[")
+
+	for i, l := 0, slice.Len(); i < l; i++ {
+		if err := me.Literal(buf, slice.Index(i).Interface()); err != nil {
+			return err
+		}
+		if i < l - 1 {
+			buf.WriteRune(comma_rune)
+			buf.WriteRune(space_rune)
+		}
+	}
+	buf.WriteRune(']')
+	return nil
+}
+
 func newDatasetAdapter(ds *goqu.Dataset) goqu.Adapter {
 	ret := goqu.NewDefaultAdapter(ds).(*goqu.DefaultAdapter)
 	ret.PlaceHolderRune = placeholder_rune
 	ret.IncludePlaceholderNum = true
-	return ret
+	return &DatasetAdapter{ret}
 }
+
 
 func init() {
 	goqu.RegisterAdapter("postgres", newDatasetAdapter)

--- a/crud_exec.go
+++ b/crud_exec.go
@@ -25,6 +25,11 @@ type (
 	selectResults []Record
 )
 
+var column_rename_function = strings.ToLower
+func SetColumnRenameFunction(new_function func(string) string) {
+	column_rename_function = new_function
+}
+
 var struct_map_cache = make(map[interface{}]columnMap)
 var struct_map_cache_lock = sync.Mutex{}
 
@@ -304,7 +309,7 @@ func createColumnMap(t reflect.Type) columnMap {
 		} else {
 			columnName := f.Tag.Get("db")
 			if columnName == "" {
-				columnName = strings.ToLower(f.Name)
+				columnName = column_rename_function(f.Name)
 			}
 			cm[columnName] = columnData{
 				ColumnName: columnName,

--- a/crud_exec.go
+++ b/crud_exec.go
@@ -25,9 +25,9 @@ type (
 	selectResults []Record
 )
 
-var column_rename_function = strings.ToLower
+var columnRenameFunction = strings.ToLower
 func SetColumnRenameFunction(new_function func(string) string) {
-	column_rename_function = new_function
+	columnRenameFunction = new_function
 }
 
 var struct_map_cache = make(map[interface{}]columnMap)
@@ -309,7 +309,7 @@ func createColumnMap(t reflect.Type) columnMap {
 		} else {
 			columnName := f.Tag.Get("db")
 			if columnName == "" {
-				columnName = column_rename_function(f.Name)
+				columnName = columnRenameFunction(f.Name)
 			}
 			cm[columnName] = columnData{
 				ColumnName: columnName,

--- a/crud_exec_test.go
+++ b/crud_exec_test.go
@@ -3,6 +3,7 @@ package goqu
 import (
 	"fmt"
 	"sync"
+	"strings"
 	"testing"
 
 	"github.com/c2fo/testify/assert"
@@ -160,7 +161,44 @@ func (me *crudExecTest) TestScanStructs() {
 
 	assert.Equal(t, noTags[1].Address, "211 Test Addr")
 	assert.Equal(t, noTags[1].Name, "Test2")
+}
 
+func (me *crudExecTest) TestColumnRename() {
+	t := me.T()
+	// different key names are used each time to circumvent the caching that happens
+	// it seems like a solid assumption that when people use this feature,
+	// they would simply set a renaming function once at startup,
+	// and not change between requests like this
+	lowerAnon := struct {
+		FirstLower string
+		LastLower string
+	}{}
+	lowerColumnMap, lowerErr := getColumnMap(&lowerAnon)
+	assert.NoError(t, lowerErr)
+
+	var lowerKeys []string
+	for key, _ := range lowerColumnMap {
+		lowerKeys = append(lowerKeys, key)
+	}
+	assert.Contains(t, lowerKeys, "firstlower")
+	assert.Contains(t, lowerKeys, "lastlower")
+
+	// changing rename function
+	SetColumnRenameFunction(strings.ToUpper)
+
+	upperAnon := struct {
+		FirstUpper string
+		LastUpper string
+	}{}
+	upperColumnMap, upperErr := getColumnMap(&upperAnon)
+	assert.NoError(t, upperErr)
+
+	var upperKeys []string
+	for key, _ := range upperColumnMap {
+		upperKeys = append(upperKeys, key)
+	}
+	assert.Contains(t, upperKeys, "FIRSTUPPER")
+	assert.Contains(t, upperKeys, "LASTUPPER")
 }
 
 func (me *crudExecTest) TestScanStruct() {

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -410,14 +410,35 @@ func (me *DefaultAdapter) InsertValuesSql(buf *SqlBuilder, values [][]interface{
 		if len(row) != rowLen {
 			return fmt.Errorf("Rows with different value length expected %d got %d", rowLen, len(row))
 		}
-		if err := me.Literal(buf, row); err != nil {
+
+		if err := me.Record(buf, row, rowLen); err != nil {
 			return err
 		}
+
 		if i < valueLen-1 {
 			buf.WriteRune(comma_rune)
 			buf.WriteRune(space_rune)
 		}
 	}
+	return nil
+}
+
+func (me *DefaultAdapter) Record(buf *SqlBuilder, values []interface{}, valuesLen int) error {
+	buf.WriteRune(left_paren_rune)
+
+	for i, value := range values {
+		if err := me.Literal(buf, value); err != nil {
+			return err
+		}
+
+		if i < valuesLen - 1 {
+			buf.WriteRune(comma_rune)
+			buf.WriteRune(space_rune)
+		}
+	}
+
+	buf.WriteRune(right_paren_rune)
+
 	return nil
 }
 

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -430,9 +430,16 @@ func (me *DefaultAdapter) OnConflictSql(buf *SqlBuilder, o ConflictExpression) e
 	if u := o.Updates(); u != nil {
 		target := u.Target
 		if me.SupportsConflictTarget() && target != "" {
-			buf.Write([]byte(" ("))
+			wrapParens := !strings.HasPrefix(strings.ToLower(target), "on constraint")
+
+			buf.Write([]byte(" "))
+			if wrapParens {
+				buf.Write([]byte("("))
+			}
 			buf.Write([]byte(target))
-			buf.Write([]byte(")"))
+			if wrapParens {
+				buf.Write([]byte(")"))
+			}
 		}
 		if err := me.onConflictDoUpdateSql(buf, *u); err != nil {
 			return err


### PR DESCRIPTION
I accidentally included commits from the other pull request I currently have open, but this pull request just highlights a problem the default adapter has with postgres. [`ARRAY` types](http://www.postgresqltutorial.com/postgresql-array/) have a different syntax than the values given to `INSERT`, so when I fixed the adapter to serialize postgres arrays properly, it also broke insert statements. This pull request creates a distinction between a `Literal` and a `Record`, which clears this up.

If there's anything you'd like me to change or add, just let me know :smile: 