### PR TITLE
Update crud_exec.go

### DIFF
--- a/crud_exec.go
+++ b/crud_exec.go
@@ -294,11 +294,7 @@ func assignVals(i interface{}, results []Record, cm columnMap) error {
 			if ok {
 				srcVal := reflect.ValueOf(src)
 				f := val.FieldByName(data.FieldName)
-				if f.Kind() == reflect.Ptr {
-					f.Set(reflect.ValueOf(srcVal))
-				} else {
-					f.Set(reflect.Indirect(srcVal))
-				}
+				f.Set(reflect.Indirect(srcVal))
 			}
 		}
 	case reflect.Slice:


### PR DESCRIPTION
error on case:
```
type User struct {
	Id        string       `json:"id" db:"id"`
	Email        string       `json:"email" db:"email"`
	Name         string       `json:"name" db:"name"`
	Photo        *string      `json:"photo" db:"photo"` // <<-- here
	Deleted      *time.Time   `json:"-" db:"deleted_at"`  // <<-- here
	CreatedAt    time.Time    `json:"-" db:"-"`
}
var item models.User
found, err := dataset.Where(goqu.I(`id`).Eq(1)).ScanStruct(&item)
```
Errors:
- panic: reflect.Set: value of type reflect.Value is not assignable to type *string
- panic: reflect.Set: value of type reflect.Value is not assignable to type *time.Time