### PR TITLE
v7.1.0 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v7.1.0
+
+* [FIXED] Embedded pointers with property names that duplicate parent struct properties. [#23](https://github.com/doug-martin/goqu/issues/23)
+
 ## v7.0.1
 
 * Fix issue where structs with pointer fields where not set properly [#86](https://github.com/doug-martin/goqu/pull/86) and [#89](https://github.com/doug-martin/goqu/pull/89) - [@efureev](https://github.com/efureev)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 ## v7.1.0
 
 * [FIXED] Embedded pointers with property names that duplicate parent struct properties. [#23](https://github.com/doug-martin/goqu/issues/23)
+* [FIXED] Can't scan values using []byte or []string [#90](https://github.com/doug-martin/goqu/issues/90)
+    * When a slice that is `*sql.RawBytes`, `*[]byte` or `sql.Scanner` no errors will be returned. 
 
 ## v7.0.1
 

--- a/exec/query_executor.go
+++ b/exec/query_executor.go
@@ -203,13 +203,19 @@ func (q QueryExecutor) ScanValContext(ctx context.Context, i interface{}) (bool,
 	}
 	val = reflect.Indirect(val)
 	if util.IsSlice(val.Kind()) {
-		return false, errScanValNonSlice
+		switch i.(type) {
+		case *sql.RawBytes: // do nothing
+		case *[]byte: // do nothing
+		case sql.Scanner: // do nothing
+		default:
+			return false, errScanValNonSlice
+		}
 	}
 	rows, err := q.QueryContext(ctx)
 	if err != nil {
 		return false, err
 	}
-	return NewScanner(rows).ScanVals(i)
+	return NewScanner(rows).ScanVal(i)
 }
 
 func (q QueryExecutor) rowsScanner(ctx context.Context) (Scanner, error) {

--- a/internal/util/reflect_test.go
+++ b/internal/util/reflect_test.go
@@ -722,10 +722,10 @@ func (rt *reflectTest) TestGetColumnMap_withStruct() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldName: "Str", GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldName: "Int", GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldName: "Bool", GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldName: "Valuer", GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -742,10 +742,10 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithTag() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"s": {ColumnName: "s", FieldName: "Str", GoType: reflect.TypeOf("")},
-		"i": {ColumnName: "i", FieldName: "Int", GoType: reflect.TypeOf(int64(1))},
-		"b": {ColumnName: "b", FieldName: "Bool", GoType: reflect.TypeOf(true)},
-		"v": {ColumnName: "v", FieldName: "Valuer", GoType: reflect.TypeOf(&sql.NullString{})},
+		"s": {ColumnName: "s", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
+		"i": {ColumnName: "i", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
+		"b": {ColumnName: "b", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
+		"v": {ColumnName: "v", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -762,9 +762,9 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithTransientFields() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":  {ColumnName: "str", FieldName: "Str", GoType: reflect.TypeOf("")},
-		"int":  {ColumnName: "int", FieldName: "Int", GoType: reflect.TypeOf(int64(1))},
-		"bool": {ColumnName: "bool", FieldName: "Bool", GoType: reflect.TypeOf(true)},
+		"str":  {ColumnName: "str", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
+		"int":  {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
+		"bool": {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
 	}, cm)
 }
 
@@ -781,10 +781,10 @@ func (rt *reflectTest) TestGetColumnMap_withSliceOfStructs() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldName: "Str", GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldName: "Int", GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldName: "Bool", GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldName: "Valuer", GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -813,10 +813,10 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithEmbeddedStruct() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldName: "Str", GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldName: "Int", GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldName: "Bool", GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldName: "Valuer", GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0, 0}, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -836,10 +836,10 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithEmbeddedStructPointer() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldName: "Str", GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldName: "Int", GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldName: "Bool", GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldName: "Valuer", GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0, 0}, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 


### PR DESCRIPTION
* [FIXED] Embedded pointers with property names that duplicate parent struct properties. #23
* [FIXED] Can't scan values using []byte or []string #90
    * When a slice that is `*sql.RawBytes`, `*[]byte` or `sql.Scanner` no errors will be returned. 