### PR TITLE
V7.3.0 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## v7.3.0
 
 * [ADDED] UPDATE and INSERT should use struct Field name if db tag is not specified [#57](https://github.com/doug-martin/goqu/issues/57)
+* [CHANGE] Changed goqu.Database to accept a SQLDatabase interface to allow using goqu.Database with other libraries such as `sqlx` [#95](https://github.com/doug-martin/goqu/issues/95)
 
 ## v7.2.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v7.3.0
+
+* [ADDED] UPDATE and INSERT should use struct Field name if db tag is not specified [#57](https://github.com/doug-martin/goqu/issues/57)
+
 ## v7.2.0
 
 * [FIXED] Sqlite3 does not accept SELECT * UNION (SELECT *) [#79](https://github.com/doug-martin/goqu/issues/79)

--- a/database.go
+++ b/database.go
@@ -11,12 +11,21 @@ type (
 	Logger interface {
 		Printf(format string, v ...interface{})
 	}
+	// Interface for sql.DB, an interface is used so you can use with other
+	// libraries such as sqlx instead of the native sql.DB
+	SQLDatabase interface {
+		Begin() (*sql.Tx, error)
+		ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+		PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+		QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+		QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	}
 	// This struct is the wrapper for a Db. The struct delegates most calls to either an Exec instance or to the Db
 	// passed into the constructor.
 	Database struct {
 		logger  Logger
 		dialect string
-		Db      *sql.DB
+		Db      SQLDatabase
 		qf      exec.QueryFactory
 	}
 )
@@ -49,7 +58,7 @@ type (
 //              panic(err.Error())
 //          }
 //          fmt.Printf("%+v", ids)
-func newDatabase(dialect string, db *sql.DB) *Database {
+func newDatabase(dialect string, db SQLDatabase) *Database {
 	return &Database{dialect: dialect, Db: db}
 }
 

--- a/dataset_sql_test.go
+++ b/dataset_sql_test.go
@@ -183,7 +183,7 @@ func (dit *datasetIntegrationTest) TestToInsertSQLWithStructs() {
 	insertSQL, _, err := ds1.ToInsertSQL(item{Name: "Test", Address: "111 Test Addr", Created: created})
 	assert.NoError(t, err)
 	assert.Equal(t, insertSQL,
-		`INSERT INTO "items" ("address", "name", "created") VALUES ('111 Test Addr', 'Test', '`+created.Format(time.RFC3339Nano)+`')`,
+		`INSERT INTO "items" ("address", "created", "name") VALUES ('111 Test Addr', '`+created.Format(time.RFC3339Nano)+`', 'Test')`,
 	) // #nosec
 
 	insertSQL, _, err = ds1.ToInsertSQL(
@@ -194,11 +194,11 @@ func (dit *datasetIntegrationTest) TestToInsertSQLWithStructs() {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, insertSQL,
-		`INSERT INTO "items" ("address", "name", "created") VALUES `+
-			`('111 Test Addr', 'Test1', '`+created.Format(time.RFC3339Nano)+`'), `+
-			`('211 Test Addr', 'Test2', '`+created.Format(time.RFC3339Nano)+`'), `+
-			`('311 Test Addr', 'Test3', '`+created.Format(time.RFC3339Nano)+`'), `+
-			`('411 Test Addr', 'Test4', '`+created.Format(time.RFC3339Nano)+`')`,
+		`INSERT INTO "items" ("address", "created", "name") VALUES `+
+			`('111 Test Addr', '`+created.Format(time.RFC3339Nano)+`', 'Test1'), `+
+			`('211 Test Addr', '`+created.Format(time.RFC3339Nano)+`', 'Test2'), `+
+			`('311 Test Addr', '`+created.Format(time.RFC3339Nano)+`', 'Test3'), `+
+			`('411 Test Addr', '`+created.Format(time.RFC3339Nano)+`', 'Test4')`,
 	)
 }
 
@@ -223,8 +223,8 @@ func (dit *datasetIntegrationTest) TestToInsertSQLWithEmbeddedStruct() {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, insertSQL, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES `+
-		`('456456', '123123', '111 Test Addr', 'Test')`)
+	assert.Equal(t, insertSQL, `INSERT INTO "items" ("address", "home_phone", "name", "primary_phone") VALUES `+
+		`('111 Test Addr', '123123', 'Test', '456456')`)
 
 	insertSQL, _, err = ds1.ToInsertSQL(
 		item{Address: "111 Test Addr", Name: "Test1", Phone: Phone{Home: "123123", Primary: "456456"}},
@@ -233,11 +233,11 @@ func (dit *datasetIntegrationTest) TestToInsertSQLWithEmbeddedStruct() {
 		item{Address: "411 Test Addr", Name: "Test4", Phone: Phone{Home: "123123", Primary: "456456"}},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, insertSQL, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES `+
-		`('456456', '123123', '111 Test Addr', 'Test1'), `+
-		`('456456', '123123', '211 Test Addr', 'Test2'), `+
-		`('456456', '123123', '311 Test Addr', 'Test3'), `+
-		`('456456', '123123', '411 Test Addr', 'Test4')`)
+	assert.Equal(t, insertSQL, `INSERT INTO "items" ("address", "home_phone", "name", "primary_phone") VALUES `+
+		`('111 Test Addr', '123123', 'Test1', '456456'), `+
+		`('211 Test Addr', '123123', 'Test2', '456456'), `+
+		`('311 Test Addr', '123123', 'Test3', '456456'), `+
+		`('411 Test Addr', '123123', 'Test4', '456456')`)
 }
 
 func (dit *datasetIntegrationTest) TestToInsertSQLWithEmbeddedStructPtr() {
@@ -261,8 +261,8 @@ func (dit *datasetIntegrationTest) TestToInsertSQLWithEmbeddedStructPtr() {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, insertSQL, `INSERT INTO "items" `+
-		`("primary_phone", "home_phone", "address", "name", "valuer")`+
-		` VALUES ('456456', '123123', '111 Test Addr', 'Test', 10)`)
+		`("address", "home_phone", "name", "primary_phone", "valuer")`+
+		` VALUES ('111 Test Addr', '123123', 'Test', '456456', 10)`)
 
 	insertSQL, _, err = ds1.ToInsertSQL(
 		item{Address: "111 Test Addr", Name: "Test1", Phone: &Phone{Home: "123123", Primary: "456456"}},
@@ -272,11 +272,11 @@ func (dit *datasetIntegrationTest) TestToInsertSQLWithEmbeddedStructPtr() {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, insertSQL,
-		`INSERT INTO "items" ("primary_phone", "home_phone", "address", "name", "valuer") VALUES `+
-			`('456456', '123123', '111 Test Addr', 'Test1', NULL), `+
-			`('456456', '123123', '211 Test Addr', 'Test2', NULL), `+
-			`('456456', '123123', '311 Test Addr', 'Test3', NULL), `+
-			`('456456', '123123', '411 Test Addr', 'Test4', NULL)`)
+		`INSERT INTO "items" ("address", "home_phone", "name", "primary_phone", "valuer") VALUES `+
+			`('111 Test Addr', '123123', 'Test1', '456456', NULL), `+
+			`('211 Test Addr', '123123', 'Test2', '456456', NULL), `+
+			`('311 Test Addr', '123123', 'Test3', '456456', NULL), `+
+			`('411 Test Addr', '123123', 'Test4', '456456', NULL)`)
 }
 
 func (dit *datasetIntegrationTest) TestToInsertSQLWithValuer() {
@@ -762,11 +762,11 @@ func (dit *datasetIntegrationTest) TestPreparedToInsertSQLWithEmbeddedStruct() {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"456456", "123123", "111 Test Addr", "Test"})
+	assert.Equal(t, args, []interface{}{"111 Test Addr", "123123", "Test", "456456"})
 	assert.Equal(
 		t,
 		insertSQL,
-		`INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES (?, ?, ?, ?)`,
+		`INSERT INTO "items" ("address", "home_phone", "name", "primary_phone") VALUES (?, ?, ?, ?)`,
 	)
 
 	insertSQL, args, err = ds1.Prepared(true).ToInsertSQL(
@@ -777,12 +777,12 @@ func (dit *datasetIntegrationTest) TestPreparedToInsertSQLWithEmbeddedStruct() {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{
-		"456456", "123123", "111 Test Addr", "Test1",
-		"456456", "123123", "211 Test Addr", "Test2",
-		"456456", "123123", "311 Test Addr", "Test3",
-		"456456", "123123", "411 Test Addr", "Test4",
+		"111 Test Addr", "123123", "Test1", "456456",
+		"211 Test Addr", "123123", "Test2", "456456",
+		"311 Test Addr", "123123", "Test3", "456456",
+		"411 Test Addr", "123123", "Test4", "456456",
 	})
-	assert.Equal(t, insertSQL, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES `+
+	assert.Equal(t, insertSQL, `INSERT INTO "items" ("address", "home_phone", "name", "primary_phone") VALUES `+
 		`(?, ?, ?, ?), `+
 		`(?, ?, ?, ?), `+
 		`(?, ?, ?, ?), `+
@@ -810,11 +810,11 @@ func (dit *datasetIntegrationTest) TestPreparedToInsertSQLWithEmbeddedStructPtr(
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"456456", "123123", "111 Test Addr", "Test"})
+	assert.Equal(t, args, []interface{}{"111 Test Addr", "123123", "Test", "456456"})
 	assert.Equal(
 		t,
 		insertSQL,
-		`INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES (?, ?, ?, ?)`,
+		`INSERT INTO "items" ("address", "home_phone", "name", "primary_phone") VALUES (?, ?, ?, ?)`,
 	)
 
 	insertSQL, args, err = ds1.Prepared(true).ToInsertSQL(
@@ -825,12 +825,12 @@ func (dit *datasetIntegrationTest) TestPreparedToInsertSQLWithEmbeddedStructPtr(
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{
-		"456456", "123123", "111 Test Addr", "Test1",
-		"456456", "123123", "211 Test Addr", "Test2",
-		"456456", "123123", "311 Test Addr", "Test3",
-		"456456", "123123", "411 Test Addr", "Test4",
+		"111 Test Addr", "123123", "Test1", "456456",
+		"211 Test Addr", "123123", "Test2", "456456",
+		"311 Test Addr", "123123", "Test3", "456456",
+		"411 Test Addr", "123123", "Test4", "456456",
 	})
-	assert.Equal(t, insertSQL, `INSERT INTO "items" ("primary_phone", "home_phone", "address", "name") VALUES `+
+	assert.Equal(t, insertSQL, `INSERT INTO "items" ("address", "home_phone", "name", "primary_phone") VALUES `+
 		`(?, ?, ?, ?), `+
 		`(?, ?, ?, ?), `+
 		`(?, ?, ?, ?), `+
@@ -1082,7 +1082,7 @@ func (dit *datasetIntegrationTest) TestToUpdateSQLWithByteSlice() {
 		Returning(T("items").All()).
 		ToUpdateSQL(item{Name: "Test", Data: []byte(`{"someJson":"data"}`)})
 	assert.NoError(t, err)
-	assert.Equal(t, `UPDATE "items" SET "name"='Test',"data"='{"someJson":"data"}' RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"='{"someJson":"data"}',"name"='Test' RETURNING "items".*`, updateSQL)
 }
 
 type valuerType []byte
@@ -1102,7 +1102,7 @@ func (dit *datasetIntegrationTest) TestToUpdateSQLWithCustomValuer() {
 		Returning(T("items").All()).
 		ToUpdateSQL(item{Name: "Test", Data: []byte(`Hello`)})
 	assert.NoError(t, err)
-	assert.Equal(t, `UPDATE "items" SET "name"='Test',"data"='Hello World' RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"='Hello World',"name"='Test' RETURNING "items".*`, updateSQL)
 }
 
 func (dit *datasetIntegrationTest) TestToUpdateSQLWithValuer() {
@@ -1117,7 +1117,7 @@ func (dit *datasetIntegrationTest) TestToUpdateSQLWithValuer() {
 		Returning(T("items").All()).
 		ToUpdateSQL(item{Name: "Test", Data: sql.NullString{String: "Hello World", Valid: true}})
 	assert.NoError(t, err)
-	assert.Equal(t, `UPDATE "items" SET "name"='Test',"data"='Hello World' RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"='Hello World',"name"='Test' RETURNING "items".*`, updateSQL)
 }
 
 func (dit *datasetIntegrationTest) TestToUpdateSQLWithValuerNull() {
@@ -1129,7 +1129,7 @@ func (dit *datasetIntegrationTest) TestToUpdateSQLWithValuerNull() {
 	}
 	updateSQL, _, err := ds1.Returning(T("items").All()).ToUpdateSQL(item{Name: "Test"})
 	assert.NoError(t, err)
-	assert.Equal(t, `UPDATE "items" SET "name"='Test',"data"=NULL RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"=NULL,"name"='Test' RETURNING "items".*`, updateSQL)
 }
 
 func (dit *datasetIntegrationTest) TestToUpdateSQLWithEmbeddedStruct() {
@@ -1162,12 +1162,12 @@ func (dit *datasetIntegrationTest) TestToUpdateSQLWithEmbeddedStruct() {
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{})
 	assert.Equal(t, `UPDATE "items" SET `+
-		`"primary_phone"='456456',`+
-		`"home_phone"='123123',`+
-		`"phone_created"='2015-01-01T00:00:00Z',`+
-		`"name"='Test',`+
 		`"created"='2015-01-01T00:00:00Z',`+
-		`"nil_pointer"=NULL`, updateSQL)
+		`"home_phone"='123123',`+
+		`"name"='Test',`+
+		`"nil_pointer"=NULL,`+
+		`"phone_created"='2015-01-01T00:00:00Z',`+
+		`"primary_phone"='456456'`, updateSQL)
 }
 
 func (dit *datasetIntegrationTest) TestToUpdateSQLWithEmbeddedStructPtr() {
@@ -1199,11 +1199,11 @@ func (dit *datasetIntegrationTest) TestToUpdateSQLWithEmbeddedStructPtr() {
 	assert.NoError(t, err)
 	assert.Equal(t, args, []interface{}{})
 	assert.Equal(t, `UPDATE "items" SET `+
-		`"primary_phone"='456456',`+
+		`"created"='2015-01-01T00:00:00Z',`+
 		`"home_phone"='123123',`+
-		`"phone_created"='2015-01-01T00:00:00Z',`+
 		`"name"='Test',`+
-		`"created"='2015-01-01T00:00:00Z'`, updateSQL)
+		`"phone_created"='2015-01-01T00:00:00Z',`+
+		`"primary_phone"='456456'`, updateSQL)
 }
 
 func (dit *datasetIntegrationTest) TestToUpdateSQLWithUnsupportedType() {
@@ -1305,8 +1305,8 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithByteSlice() {
 		Prepared(true).
 		ToUpdateSQL(item{Name: "Test", Data: []byte(`{"someJson":"data"}`)})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"Test", []byte(`{"someJson":"data"}`)})
-	assert.Equal(t, `UPDATE "items" SET "name"=?,"data"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"=?,"name"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, args, []interface{}{[]byte(`{"someJson":"data"}`), "Test"})
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithCustomValuer() {
@@ -1321,8 +1321,8 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithCustomValuer() {
 		Prepared(true).
 		ToUpdateSQL(item{Name: "Test", Data: []byte(`Hello`)})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"Test", []byte("Hello World")})
-	assert.Equal(t, `UPDATE "items" SET "name"=?,"data"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"=?,"name"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, args, []interface{}{[]byte("Hello World"), "Test"})
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithValuer() {
@@ -1337,8 +1337,8 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithValuer() {
 		Prepared(true).
 		ToUpdateSQL(item{Name: "Test", Data: sql.NullString{String: "Hello World", Valid: true}})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"Test", "Hello World"})
-	assert.Equal(t, `UPDATE "items" SET "name"=?,"data"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, `UPDATE "items" SET "data"=?,"name"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, args, []interface{}{"Hello World", "Test"})
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithSkipupdateTag() {
@@ -1350,8 +1350,8 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithSkipupdateTag() {
 	}
 	updateSQL, args, err := ds1.Prepared(true).ToUpdateSQL(item{Name: "Test", Address: "111 Test Addr"})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"Test"})
 	assert.Equal(t, `UPDATE "items" SET "name"=?`, updateSQL)
+	assert.Equal(t, args, []interface{}{"Test"})
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithEmbeddedStruct() {
@@ -1382,9 +1382,9 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithEmbeddedStruct() {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"456456", "123123", created, "Test", created})
 	assert.Equal(t, `UPDATE "items" `+
-		`SET "primary_phone"=?,"home_phone"=?,"phone_created"=?,"name"=?,"created"=?,"nil_pointer"=NULL`, updateSQL)
+		`SET "created"=?,"home_phone"=?,"name"=?,"nil_pointer"=NULL,"phone_created"=?,"primary_phone"=?`, updateSQL)
+	assert.Equal(t, []interface{}{created, "123123", "Test", created, "456456"}, args)
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithEmbeddedStructPtr() {
@@ -1414,11 +1414,9 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithEmbeddedStructPtr(
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"456456", "123123", created, "Test", created})
-	assert.Equal(t,
-		`UPDATE "items" SET "primary_phone"=?,"home_phone"=?,"phone_created"=?,"name"=?,"created"=?`,
-		updateSQL,
-	)
+	assert.Equal(t, `UPDATE "items" `+
+		`SET "created"=?,"home_phone"=?,"name"=?,"phone_created"=?,"primary_phone"=?`, updateSQL)
+	assert.Equal(t, []interface{}{created, "123123", "Test", created, "456456"}, args)
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithWhere() {
@@ -1433,16 +1431,16 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithWhere() {
 		Prepared(true).
 		ToUpdateSQL(item{Name: "Test", Address: "111 Test Addr"})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 	assert.Equal(t, `UPDATE "items" SET "address"=?,"name"=? WHERE ("name" IS NULL)`, updateSQL)
+	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 
 	updateSQL, args, err = ds1.
 		Where(C("name").IsNull()).
 		Prepared(true).
 		ToUpdateSQL(Record{"name": "Test", "address": "111 Test Addr"})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 	assert.Equal(t, `UPDATE "items" SET "address"=?,"name"=? WHERE ("name" IS NULL)`, updateSQL)
+	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 }
 
 func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithReturning() {
@@ -1457,8 +1455,8 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithReturning() {
 		Prepared(true).
 		ToUpdateSQL(item{Name: "Test", Address: "111 Test Addr"})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 	assert.Equal(t, `UPDATE "items" SET "address"=?,"name"=? RETURNING "items".*`, updateSQL)
+	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 
 	updateSQL, args, err = ds1.
 		Where(C("name").IsNull()).
@@ -1466,8 +1464,8 @@ func (dit *datasetIntegrationTest) TestPreparedToUpdateSQLWithReturning() {
 		Prepared(true).
 		ToUpdateSQL(Record{"name": "Test", "address": "111 Test Addr"})
 	assert.NoError(t, err)
-	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 	assert.Equal(t, `UPDATE "items" SET "address"=?,"name"=? WHERE ("name" IS NULL) RETURNING "items".*`, updateSQL)
+	assert.Equal(t, args, []interface{}{"111 Test Addr", "Test"})
 }
 
 func (dit *datasetIntegrationTest) TestSelect() {

--- a/exec/scanner_test.go
+++ b/exec/scanner_test.go
@@ -58,21 +58,6 @@ var (
 	testName2 = "Test2"
 )
 
-type mockDB struct {
-	db *sql.DB
-}
-
-func newMockDb(db *sql.DB) DbExecutor {
-	return &mockDB{db: db}
-}
-
-func (m *mockDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	return m.db.ExecContext(ctx, query, args...)
-}
-func (m *mockDB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
-	return m.db.QueryContext(ctx, query, args...)
-}
-
 type crudExecTest struct {
 	suite.Suite
 }
@@ -80,9 +65,8 @@ type crudExecTest struct {
 func (cet *crudExecTest) TestWithError() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, _, err := sqlmock.New()
+	db, _, err := sqlmock.New()
 	assert.NoError(t, err)
-	db := newMockDb(mDb)
 	expectedErr := fmt.Errorf("crud exec error")
 	e := newQueryExecutor(db, expectedErr, `SELECT * FROM "items"`)
 	var items []TestCrudActionItem
@@ -108,7 +92,7 @@ func (cet *crudExecTest) TestWithError() {
 
 func (cet *crudExecTest) TestScanStructs_withTaggedFields() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -116,7 +100,6 @@ func (cet *crudExecTest) TestScanStructs_withTaggedFields() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionItem
@@ -129,7 +112,7 @@ func (cet *crudExecTest) TestScanStructs_withTaggedFields() {
 
 func (cet *crudExecTest) TestScanStructs_withUntaggedFields() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -137,7 +120,6 @@ func (cet *crudExecTest) TestScanStructs_withUntaggedFields() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionNoTagsItem
@@ -150,7 +132,7 @@ func (cet *crudExecTest) TestScanStructs_withUntaggedFields() {
 
 func (cet *crudExecTest) TestScanStructs_withPointerFields() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -158,7 +140,6 @@ func (cet *crudExecTest) TestScanStructs_withPointerFields() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionWithPointerField
@@ -171,7 +152,7 @@ func (cet *crudExecTest) TestScanStructs_withPointerFields() {
 
 func (cet *crudExecTest) TestScanStructs_pointers() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -179,7 +160,6 @@ func (cet *crudExecTest) TestScanStructs_pointers() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []*TestCrudActionItem
@@ -192,7 +172,7 @@ func (cet *crudExecTest) TestScanStructs_pointers() {
 
 func (cet *crudExecTest) TestScanStructs_withEmbeddedStruct() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -200,7 +180,6 @@ func (cet *crudExecTest) TestScanStructs_withEmbeddedStruct() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []TestComposedCrudActionItem
@@ -213,7 +192,7 @@ func (cet *crudExecTest) TestScanStructs_withEmbeddedStruct() {
 
 func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStruct() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -221,7 +200,6 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStruct() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []*TestComposedCrudActionItem
@@ -234,7 +212,7 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStruct() {
 
 func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStructDuplicateFields() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -242,7 +220,6 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStructDuplicateFiel
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "other_address", "other_name"}).
 			FromCSVString("111 Test Addr,Test1,111 Test Addr Other,Test1 Other\n211 Test Addr,Test2,211 Test Addr Other,Test2 Other"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []*TestComposedDuplicateFieldsItem
@@ -263,7 +240,7 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStructDuplicateFiel
 
 func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedPointerDuplicateFields() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -271,7 +248,6 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedPointerDuplicateFie
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "other_address", "other_name"}).
 			FromCSVString("111 Test Addr,Test1,111 Test Addr Other,Test1 Other\n211 Test Addr,Test2,211 Test Addr Other,Test2 Other"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []*TestComposedPointerDuplicateFieldsItem
@@ -292,7 +268,7 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedPointerDuplicateFie
 
 func (cet *crudExecTest) TestScanStructs_withEmbeddedStructPointer() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -300,7 +276,6 @@ func (cet *crudExecTest) TestScanStructs_withEmbeddedStructPointer() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []TestEmbeddedPtrCrudActionItem
@@ -313,7 +288,7 @@ func (cet *crudExecTest) TestScanStructs_withEmbeddedStructPointer() {
 
 func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStructPointer() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -321,7 +296,6 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStructPointer() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []*TestEmbeddedPtrCrudActionItem
@@ -334,10 +308,9 @@ func (cet *crudExecTest) TestScanStructs_pointersWithEmbeddedStructPointer() {
 
 func (cet *crudExecTest) TestScanStructs_badValue() {
 	t := cet.T()
-	mDb, _, err := sqlmock.New()
+	db, _, err := sqlmock.New()
 	assert.NoError(t, err)
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionItem
@@ -347,13 +320,12 @@ func (cet *crudExecTest) TestScanStructs_badValue() {
 
 func (cet *crudExecTest) TestScanStructs_queryError() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
 		WillReturnError(fmt.Errorf("queryExecutor error"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionItem
@@ -363,7 +335,7 @@ func (cet *crudExecTest) TestScanStructs_queryError() {
 func (cet *crudExecTest) TestScanStructsContext_withTaggedFields() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -371,7 +343,6 @@ func (cet *crudExecTest) TestScanStructsContext_withTaggedFields() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionItem
@@ -385,7 +356,7 @@ func (cet *crudExecTest) TestScanStructsContext_withTaggedFields() {
 func (cet *crudExecTest) TestScanStructsContext_withUntaggedFields() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -393,7 +364,6 @@ func (cet *crudExecTest) TestScanStructsContext_withUntaggedFields() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionNoTagsItem
@@ -407,7 +377,7 @@ func (cet *crudExecTest) TestScanStructsContext_withUntaggedFields() {
 func (cet *crudExecTest) TestScanStructsContext_withPointerFields() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -415,7 +385,6 @@ func (cet *crudExecTest) TestScanStructsContext_withPointerFields() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionWithPointerField
@@ -429,7 +398,7 @@ func (cet *crudExecTest) TestScanStructsContext_withPointerFields() {
 func (cet *crudExecTest) TestScanStructsContext_pointers() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -437,7 +406,6 @@ func (cet *crudExecTest) TestScanStructsContext_pointers() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []*TestCrudActionItem
@@ -451,7 +419,7 @@ func (cet *crudExecTest) TestScanStructsContext_pointers() {
 func (cet *crudExecTest) TestScanStructsContext_withEmbeddedStruct() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -459,7 +427,6 @@ func (cet *crudExecTest) TestScanStructsContext_withEmbeddedStruct() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []TestComposedCrudActionItem
@@ -473,7 +440,7 @@ func (cet *crudExecTest) TestScanStructsContext_withEmbeddedStruct() {
 func (cet *crudExecTest) TestScanStructsContext_pointersWithEmbeddedStruct() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -481,7 +448,6 @@ func (cet *crudExecTest) TestScanStructsContext_pointersWithEmbeddedStruct() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []*TestComposedCrudActionItem
@@ -495,7 +461,7 @@ func (cet *crudExecTest) TestScanStructsContext_pointersWithEmbeddedStruct() {
 func (cet *crudExecTest) TestScanStructsContext_withEmbeddedStructPointer() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -503,7 +469,6 @@ func (cet *crudExecTest) TestScanStructsContext_withEmbeddedStructPointer() {
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []TestEmbeddedPtrCrudActionItem
@@ -517,7 +482,7 @@ func (cet *crudExecTest) TestScanStructsContext_withEmbeddedStructPointer() {
 func (cet *crudExecTest) TestScanStructsContext_pointersWithEmbeddedStructPointer() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -525,7 +490,6 @@ func (cet *crudExecTest) TestScanStructsContext_pointersWithEmbeddedStructPointe
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name", "phone_number", "age"}).
 			FromCSVString("111 Test Addr,Test1,111-111-1111,20\n211 Test Addr,Test2,222-222-2222,30"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var composed []*TestEmbeddedPtrCrudActionItem
@@ -539,10 +503,9 @@ func (cet *crudExecTest) TestScanStructsContext_pointersWithEmbeddedStructPointe
 func (cet *crudExecTest) TestScanStructsContext_badValue() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, _, err := sqlmock.New()
+	db, _, err := sqlmock.New()
 	assert.NoError(t, err)
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionItem
@@ -553,13 +516,12 @@ func (cet *crudExecTest) TestScanStructsContext_badValue() {
 func (cet *crudExecTest) TestScanStructsContext_queryError() {
 	t := cet.T()
 	ctx := context.Background()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
 		WillReturnError(fmt.Errorf("queryExecutor error"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var items []TestCrudActionItem
@@ -568,7 +530,7 @@ func (cet *crudExecTest) TestScanStructsContext_queryError() {
 
 func (cet *crudExecTest) TestScanStruct() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT \* FROM "items"`).
@@ -592,7 +554,6 @@ func (cet *crudExecTest) TestScanStruct() {
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).FromCSVString("111 Test Addr,Test1"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT * FROM "items"`)
 
 	var slicePtr []TestCrudActionItem
@@ -641,7 +602,7 @@ func (cet *crudExecTest) TestScanStruct() {
 
 func (cet *crudExecTest) TestScanVals() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT "id" FROM "items"`).
@@ -655,7 +616,6 @@ func (cet *crudExecTest) TestScanVals() {
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT "id" FROM "items"`)
 
 	var id int64
@@ -676,7 +636,7 @@ func (cet *crudExecTest) TestScanVals() {
 
 func (cet *crudExecTest) TestScanVal() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT "id" FROM "items"`).
@@ -686,7 +646,6 @@ func (cet *crudExecTest) TestScanVal() {
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT "id" FROM "items"`)
 
 	var id int64
@@ -710,14 +669,13 @@ func (cet *crudExecTest) TestScanVal() {
 
 func (cet *crudExecTest) TestScanVal_withByteSlice() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT "name" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"name"}).FromCSVString("byte slice result"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT "name" FROM "items"`)
 
 	var bytes []byte
@@ -733,14 +691,13 @@ func (cet *crudExecTest) TestScanVal_withByteSlice() {
 
 func (cet *crudExecTest) TestScanVal_withRawBytes() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT "name" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"name"}).FromCSVString("byte slice result"))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT "name" FROM "items"`)
 
 	var bytes sql.RawBytes
@@ -762,14 +719,13 @@ func (b *JSONBoolArray) Scan(src interface{}) error {
 
 func (cet *crudExecTest) TestScanVal_withValuerSlice() {
 	t := cet.T()
-	mDb, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	mock.ExpectQuery(`SELECT "bools" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"bools"}).FromCSVString(`"[true, false, true]"`))
 
-	db := newMockDb(mDb)
 	e := newQueryExecutor(db, nil, `SELECT "bools" FROM "items"`)
 
 	var bools JSONBoolArray

--- a/exp/col.go
+++ b/exp/col.go
@@ -3,7 +3,6 @@ package exp
 import (
 	"fmt"
 	"reflect"
-	"sort"
 
 	"github.com/doug-martin/goqu/v7/internal/util"
 )
@@ -28,11 +27,7 @@ func NewColumnListExpression(vals ...interface{}) ColumnListExpression {
 				if err != nil {
 					panic(err.Error())
 				}
-				var structCols []string
-				for key := range cm {
-					structCols = append(structCols, key)
-				}
-				sort.Strings(structCols)
+				structCols := cm.Cols()
 				for _, col := range structCols {
 					cols = append(cols, ParseIdentifier(col))
 				}

--- a/exp/insert_test.go
+++ b/exp/insert_test.go
@@ -140,6 +140,66 @@ func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructs() {
 	assert.False(t, ie.IsInsertFrom())
 }
 
+func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructsWithoutTags() {
+	type testRecord struct {
+		FieldA int64
+		FieldB bool
+		FieldC string
+	}
+	t := iets.T()
+	ie, err := NewInsertExpression(
+		testRecord{FieldA: 1, FieldB: true, FieldC: "a"},
+		testRecord{FieldA: 2, FieldB: false, FieldC: "b"},
+	)
+	assert.NoError(t, err)
+	eie := new(insert).
+		SetCols(NewColumnListExpression("fielda", "fieldb", "fieldc")).
+		SetVals([][]interface{}{{int64(1), true, "a"}, {int64(2), false, "b"}})
+	assert.Equal(t, eie, ie)
+	assert.False(t, ie.IsEmpty())
+	assert.False(t, ie.IsInsertFrom())
+}
+
+func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructsIgnoredDbTag() {
+	type testRecord struct {
+		FieldA int64 `db:"-"`
+		FieldB bool
+		FieldC string
+	}
+	t := iets.T()
+	ie, err := NewInsertExpression(
+		testRecord{FieldA: 1, FieldB: true, FieldC: "a"},
+		testRecord{FieldA: 2, FieldB: false, FieldC: "b"},
+	)
+	assert.NoError(t, err)
+	eie := new(insert).
+		SetCols(NewColumnListExpression("fieldb", "fieldc")).
+		SetVals([][]interface{}{{true, "a"}, {false, "b"}})
+	assert.Equal(t, eie, ie)
+	assert.False(t, ie.IsEmpty())
+	assert.False(t, ie.IsInsertFrom())
+}
+
+func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructsWithGoquSkipInsert() {
+	type testRecord struct {
+		FieldA int64
+		FieldB bool   `goqu:"skipupdate"`
+		FieldC string `goqu:"skipinsert"`
+	}
+	t := iets.T()
+	ie, err := NewInsertExpression(
+		testRecord{FieldA: 1, FieldB: true, FieldC: "a"},
+		testRecord{FieldA: 2, FieldB: false, FieldC: "b"},
+	)
+	assert.NoError(t, err)
+	eie := new(insert).
+		SetCols(NewColumnListExpression("fielda", "fieldb")).
+		SetVals([][]interface{}{{int64(1), true}, {int64(2), false}})
+	assert.Equal(t, eie, ie)
+	assert.False(t, ie.IsEmpty())
+	assert.False(t, ie.IsInsertFrom())
+}
+
 func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructPointers() {
 	type testRecord struct {
 		C string `db:"c"`
@@ -177,12 +237,12 @@ func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructsWithEm
 	)
 	assert.NoError(t, err)
 	eie := new(insert).
-		SetCols(NewColumnListExpression("primary_phone", "home_phone", "address", "name")).
+		SetCols(NewColumnListExpression("address", "home_phone", "name", "primary_phone")).
 		SetVals([][]interface{}{
-			{"456456", "123123", "111 Test Addr", "Test1"},
-			{"456456", "123123", "211 Test Addr", "Test2"},
-			{"456456", "123123", "311 Test Addr", "Test3"},
-			{"456456", "123123", "411 Test Addr", "Test4"},
+			{"111 Test Addr", "123123", "Test1", "456456"},
+			{"211 Test Addr", "123123", "Test2", "456456"},
+			{"311 Test Addr", "123123", "Test3", "456456"},
+			{"411 Test Addr", "123123", "Test4", "456456"},
 		})
 	assert.Equal(t, eie, ie)
 	assert.False(t, ie.IsEmpty())
@@ -208,12 +268,12 @@ func (iets *insertExpressionTestSuite) TestNewInsertExpression_withStructsWithEm
 	)
 	assert.NoError(t, err)
 	eie := new(insert).
-		SetCols(NewColumnListExpression("primary_phone", "home_phone", "address", "name")).
+		SetCols(NewColumnListExpression("address", "home_phone", "name", "primary_phone")).
 		SetVals([][]interface{}{
-			{"456456", "123123", "111 Test Addr", "Test1"},
-			{"456456", "123123", "211 Test Addr", "Test2"},
-			{"456456", "123123", "311 Test Addr", "Test3"},
-			{"456456", "123123", "411 Test Addr", "Test4"},
+			{"111 Test Addr", "123123", "Test1", "456456"},
+			{"211 Test Addr", "123123", "Test2", "456456"},
+			{"311 Test Addr", "123123", "Test3", "456456"},
+			{"411 Test Addr", "123123", "Test4", "456456"},
 		})
 	assert.Equal(t, eie, ie)
 	assert.False(t, ie.IsEmpty())

--- a/goqu.go
+++ b/goqu.go
@@ -13,8 +13,6 @@ Please see https://github.com/doug-martin/goqu for an introduction to goqu.
 package goqu
 
 import (
-	"database/sql"
-
 	"github.com/doug-martin/goqu/v7/internal/util"
 )
 
@@ -31,11 +29,11 @@ func (dw DialectWrapper) From(table ...interface{}) *Dataset {
 	return From(table...).WithDialect(dw.dialect)
 }
 
-func (dw DialectWrapper) DB(db *sql.DB) *Database {
+func (dw DialectWrapper) DB(db SQLDatabase) *Database {
 	return newDatabase(dw.dialect, db)
 }
 
-func New(dialect string, db *sql.DB) *Database {
+func New(dialect string, db SQLDatabase) *Database {
 	return newDatabase(dialect, db)
 }
 

--- a/internal/tag/tags.go
+++ b/internal/tag/tags.go
@@ -13,28 +13,24 @@ func New(tagName string, st reflect.StructTag) Options {
 	return Options(st.Get(tagName))
 }
 
+func (o Options) Values() []string {
+	return strings.Split(string(o), ",")
+}
+
 // Contains reports whether a comma-separated list of options
 // contains a particular substr flag. substr must be surrounded by a
 // string boundary or commas.
 func (o Options) Contains(optionName string) bool {
-	if len(o) == 0 {
+	if o.IsEmpty() {
 		return false
 	}
-	ret := false
-	s := string(o)
-	for s != "" {
-		var next string
-		i := strings.Index(s, ",")
-		if i >= 0 {
-			s, next = s[:i], s[i+1:]
-		}
+	values := o.Values()
+	for _, s := range values {
 		if s == optionName {
-			ret = true
-			break
+			return true
 		}
-		s = next
 	}
-	return ret
+	return false
 }
 
 // Contains reports whether a comma-separated list of options

--- a/internal/util/reflect_test.go
+++ b/internal/util/reflect_test.go
@@ -722,10 +722,30 @@ func (rt *reflectTest) TestGetColumnMap_withStruct() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
+	}, cm)
+}
+
+func (rt *reflectTest) TestGetColumnMap_withStructGoquTags() {
+	t := rt.T()
+
+	type TestStruct struct {
+		Str    string `goqu:"skipinsert,skipupdate"`
+		Int    int64  `goqu:"skipinsert"`
+		Bool   bool   `goqu:"skipupdate"`
+		Valuer *sql.NullString
+	}
+	var ts TestStruct
+	cm, err := GetColumnMap(&ts)
+	assert.NoError(t, err)
+	assert.Equal(t, ColumnMap{
+		"str":    {ColumnName: "str", FieldIndex: []int{0}, ShouldInsert: false, ShouldUpdate: false, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: false, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: false, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -742,10 +762,30 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithTag() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"s": {ColumnName: "s", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
-		"i": {ColumnName: "i", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
-		"b": {ColumnName: "b", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
-		"v": {ColumnName: "v", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
+		"s": {ColumnName: "s", FieldIndex: []int{0}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf("")},
+		"i": {ColumnName: "i", FieldIndex: []int{1}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"b": {ColumnName: "b", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(true)},
+		"v": {ColumnName: "v", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
+	}, cm)
+}
+
+func (rt *reflectTest) TestGetColumnMap_withStructWithTagAndGoquTag() {
+	t := rt.T()
+
+	type TestStruct struct {
+		Str    string          `db:"s" goqu:"skipinsert,skipupdate"`
+		Int    int64           `db:"i" goqu:"skipinsert"`
+		Bool   bool            `db:"b" goqu:"skipupdate"`
+		Valuer *sql.NullString `db:"v"`
+	}
+	var ts TestStruct
+	cm, err := GetColumnMap(&ts)
+	assert.NoError(t, err)
+	assert.Equal(t, ColumnMap{
+		"s": {ColumnName: "s", FieldIndex: []int{0}, ShouldInsert: false, ShouldUpdate: false, GoType: reflect.TypeOf("")},
+		"i": {ColumnName: "i", FieldIndex: []int{1}, ShouldInsert: false, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"b": {ColumnName: "b", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: false, GoType: reflect.TypeOf(true)},
+		"v": {ColumnName: "v", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -762,9 +802,9 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithTransientFields() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":  {ColumnName: "str", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
-		"int":  {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
-		"bool": {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
+		"str":  {ColumnName: "str", FieldIndex: []int{0}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf("")},
+		"int":  {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool": {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(true)},
 	}, cm)
 }
 
@@ -781,10 +821,10 @@ func (rt *reflectTest) TestGetColumnMap_withSliceOfStructs() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldIndex: []int{0}, GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -813,10 +853,10 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithEmbeddedStruct() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldIndex: []int{0, 0}, GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0, 0}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 
@@ -836,10 +876,10 @@ func (rt *reflectTest) TestGetColumnMap_withStructWithEmbeddedStructPointer() {
 	cm, err := GetColumnMap(&ts)
 	assert.NoError(t, err)
 	assert.Equal(t, ColumnMap{
-		"str":    {ColumnName: "str", FieldIndex: []int{0, 0}, GoType: reflect.TypeOf("")},
-		"int":    {ColumnName: "int", FieldIndex: []int{1}, GoType: reflect.TypeOf(int64(1))},
-		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, GoType: reflect.TypeOf(true)},
-		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, GoType: reflect.TypeOf(&sql.NullString{})},
+		"str":    {ColumnName: "str", FieldIndex: []int{0, 0}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf("")},
+		"int":    {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool":   {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(true)},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
 


### PR DESCRIPTION
* [ADDED] UPDATE and INSERT should use struct Field name if db tag is not specified #57
* [CHANGE] Changed goqu.Database to accept a SQLDatabase interface to allow using goqu.Database with other libraries such as `sqlx` #95
