### PR TITLE
v7.3.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## v7.3.1
 
 * [ADDED] Exposed `goqu.NewTx` to allow creating a goqu tx directly from a `sql.Tx` instead of using `goqu.Database#Begin` [#95](https://github.com/doug-martin/goqu/issues/95)
+* [ADDED] `goqu.Database.BeginTx` [#98](https://github.com/doug-martin/goqu/issues/98)
 
 ## v7.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v7.3.1
+
+* [ADDED] Exposed `goqu.NewTx` to allow creating a goqu tx directly from a `sql.Tx` instead of using `goqu.Database#Begin` [#95](https://github.com/doug-martin/goqu/issues/95)
+
 ## v7.3.0
 
 * [ADDED] UPDATE and INSERT should use struct Field name if db tag is not specified [#57](https://github.com/doug-martin/goqu/issues/57)

--- a/database.go
+++ b/database.go
@@ -15,6 +15,7 @@ type (
 	// libraries such as sqlx instead of the native sql.DB
 	SQLDatabase interface {
 		Begin() (*sql.Tx, error)
+		BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 		ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 		PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
 		QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
@@ -70,6 +71,17 @@ func (d *Database) Dialect() string {
 // Starts a new Transaction.
 func (d *Database) Begin() (*TxDatabase, error) {
 	sqlTx, err := d.Db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	tx := NewTx(d.dialect, sqlTx)
+	tx.Logger(d.logger)
+	return tx, nil
+}
+
+// Starts a new Transaction. See sql.DB#BeginTx for option description
+func (d *Database) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxDatabase, error) {
+	sqlTx, err := d.Db.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/database_test.go
+++ b/database_test.go
@@ -1,6 +1,7 @@
 package goqu
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -247,6 +248,22 @@ func (dt *databaseTest) TestBegin() {
 	assert.Equal(t, tx.Dialect(), "mock")
 
 	_, err = db.Begin()
+	assert.EqualError(t, err, "goqu: transaction error")
+}
+
+func (dt *databaseTest) TestBeginTx() {
+	t := dt.T()
+	ctx := context.Background()
+	mDb, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	mock.ExpectBegin()
+	mock.ExpectBegin().WillReturnError(errors.New("transaction error"))
+	db := New("mock", mDb)
+	tx, err := db.BeginTx(ctx, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, tx.Dialect(), "mock")
+
+	_, err = db.BeginTx(ctx, nil)
 	assert.EqualError(t, err, "goqu: transaction error")
 }
 


### PR DESCRIPTION
* [ADDED] Exposed `goqu.NewTx` to allow creating a goqu tx directly from a `sql.Tx` instead of using `goqu.Database#Begin` #95
* [ADDED] `goqu.Database.BeginTx` #98