### PR TITLE
v7.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## v7.4.0
+
+* [FIXED] literalTime use t.UTC() , This behavior is different from the original sql.DB [#106](https://github.com/doug-martin/goqu/issues/106) - [chen56](https://github.com/chen56)
+* [ADDED] Add new method WithTx for Database [#108](https://github.com/doug-martin/goqu/issues/108) - [Xuyuanp](https://github.com/Xuyuanp)
+
 ## v7.3.1
 
 * [ADDED] Exposed `goqu.NewTx` to allow creating a goqu tx directly from a `sql.Tx` instead of using `goqu.Database#Begin` [#95](https://github.com/doug-martin/goqu/issues/95)


### PR DESCRIPTION
* [FIXED] literalTime use t.UTC() , This behavior is different from the original sql.DB #106 - @chen56
* [ADDED] Add new method WithTx for Database #108 - @Xuyuanp