### PR TITLE
Fix for #118

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+## v8.2.0
+
+* [FIX] Fix reflection errors related to nil pointers and unexported fields [#118](https://github.com/doug-martin/goqu/issues/118)
+    * Unexported fields are ignored when creating a columnMap
+    * Nil embedded pointers will no longer cause a panic
+    * Fields on nil embedded pointers will be ignored when creating update or insert statements.
+* [ADDED] You can now ingore embedded structs and their fields by using `db:"-"` tag on the embedded struct.
+
 ## v8.1.0
 
 * [ADDED] Support column DEFAULT when inserting/updating via struct [#27](https://github.com/doug-martin/goqu/issues/27)

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -128,9 +128,7 @@ type (
 )
 
 type (
-	// Alternative to writing map[string]interface{}. Can be used for Inserts, Updates or Deletes
-	Record map[string]interface{}
-	Vals   []interface{}
+	Vals []interface{}
 	// Parent of all expression types
 	Expression interface {
 		Clone() Expression

--- a/exp/record.go
+++ b/exp/record.go
@@ -1,0 +1,64 @@
+package exp
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/doug-martin/goqu/v8/internal/util"
+)
+
+// Alternative to writing map[string]interface{}. Can be used for Inserts, Updates or Deletes
+type Record map[string]interface{}
+
+func (r Record) Cols() []string {
+	cols := make([]string, 0, len(r))
+	for col := range r {
+		cols = append(cols, col)
+	}
+	sort.Strings(cols)
+	return cols
+}
+
+func NewRecordFromStruct(i interface{}, forInsert, forUpdate bool) (r Record, err error) {
+	value := reflect.ValueOf(i)
+	if value.IsValid() {
+		cm, err := util.GetColumnMap(value.Interface())
+		if err != nil {
+			return nil, err
+		}
+		cols := cm.Cols()
+		r = make(map[string]interface{})
+		for _, col := range cols {
+			f := cm[col]
+			switch {
+			case forInsert:
+				if f.ShouldInsert {
+					addFieldToRecord(r, value, f)
+				}
+			case forUpdate:
+				if f.ShouldUpdate {
+					addFieldToRecord(r, value, f)
+				}
+			default:
+				addFieldToRecord(r, value, f)
+			}
+		}
+	}
+	return
+}
+
+func addFieldToRecord(r Record, val reflect.Value, f util.ColumnData) Record {
+	v, isAvailable := util.SafeGetFieldByIndex(val, f.FieldIndex)
+	if !isAvailable {
+		return r
+	}
+	switch {
+	case f.DefaultIfEmpty && util.IsEmptyValue(v):
+		r[f.ColumnName] = Default()
+	case v.IsValid():
+		r[f.ColumnName] = v.Interface()
+	default:
+		r[f.ColumnName] = reflect.Zero(f.GoType).Interface()
+	}
+	return r
+}

--- a/exp/update.go
+++ b/exp/update.go
@@ -41,21 +41,13 @@ func NewUpdateExpressions(update interface{}) (updates []UpdateExpression, err e
 }
 
 func getUpdateExpressionsStruct(value reflect.Value) (updates []UpdateExpression, err error) {
-	cm, err := util.GetColumnMap(value.Interface())
+	r, err := NewRecordFromStruct(value.Interface(), false, true)
 	if err != nil {
 		return updates, err
 	}
-	cols := cm.Cols()
+	cols := r.Cols()
 	for _, col := range cols {
-		f := cm[col]
-		if f.ShouldUpdate {
-			v := value.FieldByIndex(f.FieldIndex)
-			setV := v.Interface()
-			if f.DefaultIfEmpty && util.IsEmptyValue(v) {
-				setV = Default()
-			}
-			updates = append(updates, ParseIdentifier(col).Set(setV))
-		}
+		updates = append(updates, ParseIdentifier(col).Set(r[col]))
 	}
 	return updates, nil
 }

--- a/exp/update_test.go
+++ b/exp/update_test.go
@@ -1,0 +1,181 @@
+package exp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type updateExpressionTestSuite struct {
+	suite.Suite
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withInvalidValue() {
+	_, err := NewUpdateExpressions(true)
+	uets.EqualError(err, "goqu: unsupported update interface type bool")
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withRecords() {
+	ie, err := NewUpdateExpressions(Record{"c": "a", "b": "d"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("b"), val: "d"},
+		update{col: ParseIdentifier("c"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withMap() {
+	ie, err := NewUpdateExpressions(map[string]interface{}{"c": "a", "b": "d"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("b"), val: "d"},
+		update{col: ParseIdentifier("c"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructs() {
+	type testRecord struct {
+		C string `db:"c"`
+		B string `db:"b"`
+	}
+	ie, err := NewUpdateExpressions(testRecord{C: "a", B: "d"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("b"), val: "d"},
+		update{col: ParseIdentifier("c"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructsWithoutTags() {
+	type testRecord struct {
+		FieldA int64
+		FieldB bool
+		FieldC string
+	}
+	ie, err := NewUpdateExpressions(testRecord{FieldA: 1, FieldB: true, FieldC: "a"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("fielda"), val: int64(1)},
+		update{col: ParseIdentifier("fieldb"), val: true},
+		update{col: ParseIdentifier("fieldc"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructsIgnoredDbTag() {
+	type testRecord struct {
+		FieldA int64 `db:"-"`
+		FieldB bool
+		FieldC string
+	}
+	ie, err := NewUpdateExpressions(testRecord{FieldA: 1, FieldB: true, FieldC: "a"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("fieldb"), val: true},
+		update{col: ParseIdentifier("fieldc"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructsWithGoquSkipUpdate() {
+	type testRecord struct {
+		FieldA int64
+		FieldB bool   `goqu:"skipupdate"`
+		FieldC string `goqu:"skipinsert"`
+	}
+	ie, err := NewUpdateExpressions(testRecord{FieldA: 1, FieldB: true, FieldC: "a"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("fielda"), val: int64(1)},
+		update{col: ParseIdentifier("fieldc"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructPointers() {
+	type testRecord struct {
+		C string `db:"c"`
+		B string `db:"b"`
+	}
+	ie, err := NewUpdateExpressions(&testRecord{C: "a", B: "d"})
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("b"), val: "d"},
+		update{col: ParseIdentifier("c"), val: "a"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructsWithEmbeddedStructs() {
+	type Phone struct {
+		Primary string `db:"primary_phone"`
+		Home    string `db:"home_phone"`
+	}
+	type item struct {
+		Phone
+		Address string `db:"address"`
+		Name    string `db:"name"`
+	}
+	ie, err := NewUpdateExpressions(
+		item{Address: "111 Test Addr", Name: "Test1", Phone: Phone{Home: "123123", Primary: "456456"}},
+	)
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("address"), val: "111 Test Addr"},
+		update{col: ParseIdentifier("home_phone"), val: "123123"},
+		update{col: ParseIdentifier("name"), val: "Test1"},
+		update{col: ParseIdentifier("primary_phone"), val: "456456"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withStructsWithEmbeddedStructPointers() {
+	type Phone struct {
+		Primary string `db:"primary_phone"`
+		Home    string `db:"home_phone"`
+	}
+	type item struct {
+		*Phone
+		Address string `db:"address"`
+		Name    string `db:"name"`
+	}
+	ie, err := NewUpdateExpressions(
+		item{Address: "111 Test Addr", Name: "Test1", Phone: &Phone{Home: "123123", Primary: "456456"}},
+	)
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("address"), val: "111 Test Addr"},
+		update{col: ParseIdentifier("home_phone"), val: "123123"},
+		update{col: ParseIdentifier("name"), val: "Test1"},
+		update{col: ParseIdentifier("primary_phone"), val: "456456"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func (uets *updateExpressionTestSuite) TestNewUpdateExpressions_withNilEmbeddedStructPointers() {
+	type Phone struct {
+		Primary string `db:"primary_phone"`
+		Home    string `db:"home_phone"`
+	}
+	type item struct {
+		*Phone
+		Address string `db:"address"`
+		Name    string `db:"name"`
+	}
+	ie, err := NewUpdateExpressions(
+		item{Address: "111 Test Addr", Name: "Test1"},
+	)
+	uets.NoError(err)
+	eie := []UpdateExpression{
+		update{col: ParseIdentifier("address"), val: "111 Test Addr"},
+		update{col: ParseIdentifier("name"), val: "Test1"},
+	}
+	uets.Equal(eie, ie)
+}
+
+func TestUpdateExpressionSuite(t *testing.T) {
+	suite.Run(t, new(updateExpressionTestSuite))
+}

--- a/issues_test.go
+++ b/issues_test.go
@@ -1,7 +1,9 @@
 package goqu_test
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/doug-martin/goqu/v8"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +34,154 @@ func (gis *githubIssuesSuite) TestIssue49() {
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 	assert.Equal(t, `SELECT * FROM "table"`, sql)
+}
+
+// Test for https://github.com/doug-martin/goqu/issues/118
+func (gis *githubIssuesSuite) TestIssue118_withEmbeddedStructWithoutExportedFields() {
+	// struct is in a custom package
+	type SimpleRole struct {
+		sync.RWMutex
+		permissions []string // nolint:structcheck,unused
+	}
+
+	// .....
+
+	type Role struct {
+		*SimpleRole
+
+		ID        string    `json:"id" db:"id" goqu:"skipinsert"`
+		Key       string    `json:"key" db:"key"`
+		Name      string    `json:"name" db:"name"`
+		CreatedAt time.Time `json:"-" db:"created_at" goqu:"skipinsert"`
+	}
+
+	rUser := &Role{
+		Key:  `user`,
+		Name: `User role`,
+	}
+
+	sql, arg, err := goqu.Insert(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Rows(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	gis.Equal(`INSERT INTO "rbac_roles" ("key", "name") VALUES ('user', 'User role') RETURNING "id"`, sql)
+
+	sql, arg, err = goqu.Update(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Set(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	gis.Equal(
+		`UPDATE "rbac_roles" SET "created_at"='0001-01-01T00:00:00Z',"id"='',"key"='user',"name"='User role' RETURNING "id"`,
+		sql,
+	)
+
+	rUser = &Role{
+		SimpleRole: &SimpleRole{},
+		Key:        `user`,
+		Name:       `User role`,
+	}
+
+	sql, arg, err = goqu.Insert(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Rows(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	gis.Equal(`INSERT INTO "rbac_roles" ("key", "name") VALUES ('user', 'User role') RETURNING "id"`, sql)
+
+	sql, arg, err = goqu.Update(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Set(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	gis.Equal(
+		`UPDATE "rbac_roles" SET `+
+			`"created_at"='0001-01-01T00:00:00Z',"id"='',"key"='user',"name"='User role' RETURNING "id"`,
+		sql,
+	)
+
+}
+
+// Test for https://github.com/doug-martin/goqu/issues/118
+func (gis *githubIssuesSuite) TestIssue118_withNilEmbeddedStructWithExportedFields() {
+	// struct is in a custom package
+	type SimpleRole struct {
+		sync.RWMutex
+		permissions []string // nolint:structcheck,unused
+		IDStr       string
+	}
+
+	// .....
+
+	type Role struct {
+		*SimpleRole
+
+		ID        string    `json:"id" db:"id" goqu:"skipinsert"`
+		Key       string    `json:"key" db:"key"`
+		Name      string    `json:"name" db:"name"`
+		CreatedAt time.Time `json:"-" db:"created_at" goqu:"skipinsert"`
+	}
+
+	rUser := &Role{
+		Key:  `user`,
+		Name: `User role`,
+	}
+	sql, arg, err := goqu.Insert(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Rows(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	// it should not insert fields on nil embedded pointers
+	gis.Equal(`INSERT INTO "rbac_roles" ("key", "name") VALUES ('user', 'User role') RETURNING "id"`, sql)
+
+	sql, arg, err = goqu.Update(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Set(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	// it should not insert fields on nil embedded pointers
+	gis.Equal(
+		`UPDATE "rbac_roles" SET "created_at"='0001-01-01T00:00:00Z',"id"='',"key"='user',"name"='User role' RETURNING "id"`,
+		sql,
+	)
+
+	rUser = &Role{
+		SimpleRole: &SimpleRole{},
+		Key:        `user`,
+		Name:       `User role`,
+	}
+	sql, arg, err = goqu.Insert(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Rows(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	// it should not insert fields on nil embedded pointers
+	gis.Equal(
+		`INSERT INTO "rbac_roles" ("idstr", "key", "name") VALUES ('', 'user', 'User role') RETURNING "id"`,
+		sql,
+	)
+
+	sql, arg, err = goqu.Update(`rbac_roles`).
+		Returning(goqu.C(`id`)).
+		Set(rUser).
+		ToSQL()
+	gis.NoError(err)
+	gis.Empty(arg)
+	// it should not insert fields on nil embedded pointers
+	gis.Equal(
+		`UPDATE "rbac_roles" SET `+
+			`"created_at"='0001-01-01T00:00:00Z',"id"='',"idstr"='',"key"='user',"name"='User role' RETURNING "id"`,
+		sql,
+	)
+
 }
 
 func TestGithubIssuesSuite(t *testing.T) {

--- a/update_dataset_example_test.go
+++ b/update_dataset_example_test.go
@@ -534,6 +534,66 @@ func ExampleUpdateDataset_Set_withNoTags() {
 	// UPDATE "items" SET "address"='111 Test Addr',"name"='Test' []
 }
 
+func ExampleUpdateDataset_Set_withEmbeddedStruct() {
+	type Address struct {
+		Street string `db:"address_street"`
+		State  string `db:"address_state"`
+	}
+	type User struct {
+		Address
+		FirstName string
+		LastName  string
+	}
+	ds := goqu.Update("user").Set(
+		User{Address: Address{Street: "111 Street", State: "NY"}, FirstName: "Greg", LastName: "Farley"},
+	)
+	updateSQL, args, _ := ds.ToSQL()
+	fmt.Println(updateSQL, args)
+
+	// Output:
+	// UPDATE "user" SET "address_state"='NY',"address_street"='111 Street',"firstname"='Greg',"lastname"='Farley' []
+}
+
+func ExampleUpdateDataset_Set_withIgnoredEmbedded() {
+	type Address struct {
+		Street string
+		State  string
+	}
+	type User struct {
+		Address   `db:"-"`
+		FirstName string
+		LastName  string
+	}
+	ds := goqu.Update("user").Set(
+		User{Address: Address{Street: "111 Street", State: "NY"}, FirstName: "Greg", LastName: "Farley"},
+	)
+	updateSQL, args, _ := ds.ToSQL()
+	fmt.Println(updateSQL, args)
+
+	// Output:
+	// UPDATE "user" SET "firstname"='Greg',"lastname"='Farley' []
+}
+
+func ExampleUpdateDataset_Set_withNilEmbeddedPointer() {
+	type Address struct {
+		Street string
+		State  string
+	}
+	type User struct {
+		*Address
+		FirstName string
+		LastName  string
+	}
+	ds := goqu.Update("user").Set(
+		User{FirstName: "Greg", LastName: "Farley"},
+	)
+	updateSQL, args, _ := ds.ToSQL()
+	fmt.Println(updateSQL, args)
+
+	// Output:
+	// UPDATE "user" SET "firstname"='Greg',"lastname"='Farley' []
+}
+
 func ExampleUpdateDataset_ToSQL_prepared() {
 	type item struct {
 		Address string `db:"address"`


### PR DESCRIPTION
* [FIX] Fix reflection errors related to nil pointers and unexported fields #118
    * Unexported fields are ignored when creating a columnMap
    * Nil embedded pointers will no longer cause a panic
    * Fields on nil embedded pointers will be ignored when creating update or insert statements.
* [ADDED] You can now ingore embedded structs and their fields by using `db:"-"` tag on the embedded struct.