### PR TITLE
bugfix: InsertDataset.WithDialect return old dataset

### DIFF
--- a/delete_dataset_test.go
+++ b/delete_dataset_test.go
@@ -47,8 +47,11 @@ func (dds *deleteDatasetSuite) TestDialect() {
 func (dds *deleteDatasetSuite) TestWithDialect() {
 	t := dds.T()
 	ds := Delete("test")
+	md := new(mocks.SQLDialect)
+	ds = ds.SetDialect(md)
+
 	dialect := GetDialect("default")
-	ds.WithDialect("default")
+	ds = ds.WithDialect("default")
 	assert.Equal(t, ds.Dialect(), dialect)
 }
 

--- a/insert_dataset.go
+++ b/insert_dataset.go
@@ -45,7 +45,7 @@ func (id *InsertDataset) IsPrepared() bool {
 func (id *InsertDataset) WithDialect(dl string) *InsertDataset {
 	ds := id.copy(id.GetClauses())
 	ds.dialect = GetDialect(dl)
-	return id
+	return ds
 }
 
 // Returns the current adapter on the dataset

--- a/insert_dataset_test.go
+++ b/insert_dataset_test.go
@@ -51,8 +51,11 @@ func (ids *insertDatasetSuite) TestDialect() {
 func (ids *insertDatasetSuite) TestWithDialect() {
 	t := ids.T()
 	ds := Insert("test")
+	md := new(mocks.SQLDialect)
+	ds = ds.SetDialect(md)
+
 	dialect := GetDialect("default")
-	ds.WithDialect("default")
+	ds = ds.WithDialect("default")
 	assert.Equal(t, ds.Dialect(), dialect)
 }
 

--- a/select_dataset_test.go
+++ b/select_dataset_test.go
@@ -44,8 +44,11 @@ func (sds *selectDatasetSuite) TestDialect() {
 func (sds *selectDatasetSuite) TestWithDialect() {
 	t := sds.T()
 	ds := From("test")
+	md := new(mocks.SQLDialect)
+	ds = ds.SetDialect(md)
+
 	dialect := GetDialect("default")
-	ds.WithDialect("default")
+	ds = ds.WithDialect("default")
 	assert.Equal(t, ds.Dialect(), dialect)
 }
 

--- a/truncate_dataset_test.go
+++ b/truncate_dataset_test.go
@@ -39,8 +39,11 @@ func (tds *truncateDatasetSuite) TestDialect() {
 func (tds *truncateDatasetSuite) TestWithDialect() {
 	t := tds.T()
 	ds := Truncate("test")
+	md := new(mocks.SQLDialect)
+	ds = ds.SetDialect(md)
+
 	dialect := GetDialect("default")
-	ds.WithDialect("default")
+	ds = ds.WithDialect("default")
 	assert.Equal(t, ds.Dialect(), dialect)
 }
 

--- a/update_dataset_test.go
+++ b/update_dataset_test.go
@@ -63,8 +63,11 @@ func (uds *updateDatasetSuite) TestDialect() {
 func (uds *updateDatasetSuite) TestWithDialect() {
 	t := uds.T()
 	ds := Update("test")
+	md := new(mocks.SQLDialect)
+	ds = ds.SetDialect(md)
+
 	dialect := GetDialect("default")
-	ds.WithDialect("default")
+	ds = ds.WithDialect("default")
 	assert.Equal(t, ds.Dialect(), dialect)
 }
 


### PR DESCRIPTION
 bugfix: InsertDataset.WithDialect return old dataset, should be return new dataset