### PR TITLE
Add Error and SetError to all datasets.

### DIFF
--- a/docs/deleting.md
+++ b/docs/deleting.md
@@ -228,8 +228,7 @@ Set an Error on a dataset:
 ```go
 func GetDelete(name string, value string) *goqu.DeleteDataset {
 
-    var ds = goqu.Delete("test").
-        Where(goqu.C(name).Eq(value))
+    var ds = goqu.Delete("test")
 
     if len(name) == 0 {
         return ds.SetError(fmt.Errorf("name is empty"))
@@ -239,7 +238,7 @@ func GetDelete(name string, value string) *goqu.DeleteDataset {
         return ds.SetError(fmt.Errorf("value is empty"))
     }
 
-    return ds
+    return ds.Where(goqu.C(name).Eq(value))
 }
 
 ```

--- a/docs/deleting.md
+++ b/docs/deleting.md
@@ -8,9 +8,10 @@
   * [Order](#order)
   * [Limit](#limit)
   * [Returning](#returning)
+  * [SetError](#seterror)
   * [Executing](#exec)
-  
-<a name="create"></a>  
+
+<a name="create"></a>
 To create a [`DeleteDataset`](https://godoc.org/github.com/doug-martin/goqu/#DeleteDataset)  you can use
 
 **[`goqu.Delete`](https://godoc.org/github.com/doug-martin/goqu/#Delete)**
@@ -212,6 +213,52 @@ fmt.Println(sql)
 Output:
 ```
 DELETE FROM "test" RETURNING "test".*
+```
+
+<a name="seterror"></a>
+**[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#DeleteDataset.SetError)**
+
+Sometimes while building up a query with goqu you will encounter situations where certain
+preconditions are not met or some end-user contraint has been violated. While you could
+track this error case separately, goqu provides a convenient built-in mechanism to set an
+error on a dataset if one has not already been set to simplify query building.
+
+Set an Error on a dataset:
+
+```go
+func GetDelete(name string, value string) *goqu.DeleteDataset {
+
+    var ds = goqu.Delete("test").
+        Where(goqu.C(name).Eq(value))
+
+    if len(name) == 0 {
+        return ds.SetError(fmt.Errorf("name is empty"))
+    }
+
+    if len(value) == 0 {
+        return ds.SetError(fmt.Errorf("value is empty"))
+    }
+
+    return ds
+}
+
+```
+
+This error is returned on any subsequent call to `Error` or `ToSQL`:
+
+```go
+var field, value string
+ds = GetDelete(field, value)
+fmt.Println(ds.Error())
+
+sql, args, err = ds.ToSQL()
+fmt.Println(err)
+```
+
+Output:
+```
+name is empty
+name is empty
 ```
 
 ## Executing Deletes

--- a/docs/inserting.md
+++ b/docs/inserting.md
@@ -8,9 +8,10 @@
   * [Insert Map](#insert-map)
   * [Insert From Query](#insert-from-query)
   * [Returning](#returning)
+  * [SetError](#seterror)
   * [Executing](#executing)
-  
-<a name="create"></a>  
+
+<a name="create"></a>
 To create a [`InsertDataset`](https://godoc.org/github.com/doug-martin/goqu/#InsertDataset)  you can use
 
 **[`goqu.Insert`](https://godoc.org/github.com/doug-martin/goqu/#Insert)**
@@ -109,7 +110,7 @@ insertSQL, args, _ := ds.ToSQL()
 fmt.Println(insertSQL, args)
 ```
 
-Output: 
+Output:
 ```sql
 INSERT INTO "user" ("first_name", "last_name") VALUES ('Greg', 'Farley'), ('Jimmy', 'Stewart'), ('Jeff', 'Jeffers') []
 ```
@@ -371,6 +372,52 @@ fmt.Println(sql)
 Output:
 ```
 INSERT INTO "test" ("a", "b") VALUES ('a', 'b') RETURNING "test".*
+```
+
+<a name="seterror"></a>
+**[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#InsertDataset.SetError)**
+
+Sometimes while building up a query with goqu you will encounter situations where certain
+preconditions are not met or some end-user contraint has been violated. While you could
+track this error case separately, goqu provides a convenient built-in mechanism to set an
+error on a dataset if one has not already been set to simplify query building.
+
+Set an Error on a dataset:
+
+```go
+func GetInsert(name string, value string) *goqu.InsertDataset {
+
+    var ds = goqu.Insert("test").
+        Rows(goqu.Record{name: value})
+
+    if len(field) == 0 {
+        return ds.SetError(fmt.Errorf("name is empty"))
+    }
+
+    if len(value) == 0 {
+        return ds.SetError(fmt.Errorf("value is empty"))
+    }
+
+    return ds
+}
+
+```
+
+This error is returned on any subsequent call to `Error` or `ToSQL`:
+
+```go
+var field, value string
+ds = GetInsert(field, value)
+fmt.Println(ds.Error())
+
+sql, args, err = ds.ToSQL()
+fmt.Println(err)
+```
+
+Output:
+```
+name is empty
+name is empty
 ```
 
 <a name="executing"></a>

--- a/docs/inserting.md
+++ b/docs/inserting.md
@@ -387,8 +387,7 @@ Set an Error on a dataset:
 ```go
 func GetInsert(name string, value string) *goqu.InsertDataset {
 
-    var ds = goqu.Insert("test").
-        Rows(goqu.Record{name: value})
+    var ds = goqu.Insert("test")
 
     if len(field) == 0 {
         return ds.SetError(fmt.Errorf("name is empty"))
@@ -398,7 +397,7 @@ func GetInsert(name string, value string) *goqu.InsertDataset {
         return ds.SetError(fmt.Errorf("value is empty"))
     }
 
-    return ds
+    return ds.Rows(goqu.Record{name: value})
 }
 
 ```

--- a/docs/selecting.md
+++ b/docs/selecting.md
@@ -12,6 +12,7 @@
   * [`GroupBy`](#group_by)
   * [`Having`](#having)
   * [`Window`](#window)
+  * [`SetError`](#seterror)
 * Executing Queries
   * [`ScanStructs`](#scan-structs) - Scans rows into a slice of structs
   * [`ScanStruct`](#scan-struct) - Scans a row into a slice a struct, returns false if a row wasnt found
@@ -20,7 +21,7 @@
   * [`Count`](#count) - Returns the count for the current query
   * [`Pluck`](#pluck) - Selects a single column and stores the results into a slice of primitive values
 
-<a name="create"></a>  
+<a name="create"></a>
 To create a [`SelectDataset`](https://godoc.org/github.com/doug-martin/goqu/#SelectDataset)  you can use
 
 **[`goqu.From`](https://godoc.org/github.com/doug-martin/goqu/#From) and [`goqu.Select`](https://godoc.org/github.com/doug-martin/goqu/#Select)**
@@ -95,7 +96,7 @@ sql, _, _ := goqu.From("test").Select("a", "b", "c").ToSQL()
 fmt.Println(sql)
 ```
 
-Output: 
+Output:
 ```sql
 SELECT "a", "b", "c" FROM "test"
 ```
@@ -647,12 +648,54 @@ Output:
 SELECT ROW_NUMBER() OVER "w" FROM "test" WINDOW "w" AS (PARTITION BY "a" ORDER BY "b")
 ```
 
+<a name="seterror"></a>
+**[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#SelectDataset.SetError)**
+
+Sometimes while building up a query with goqu you will encounter situations where certain
+preconditions are not met or some end-user contraint has been violated. While you could
+track this error case separately, goqu provides a convenient built-in mechanism to set an
+error on a dataset if one has not already been set to simplify query building.
+
+Set an Error on a dataset:
+
+```go
+func GetSelect(name string) *goqu.SelectDataset {
+
+    var ds = goqu.From("test").
+        Select(name)
+
+    if len(name) == 0 {
+        return ds.SetError(fmt.Errorf("name is empty"))
+    }
+
+    return ds
+}
+
+```
+
+This error is returned on any subsequent call to `Error` or `ToSQL`:
+
+```go
+var name string = ""
+ds = GetSelect(name)
+fmt.Println(ds.Error())
+
+sql, args, err = ds.ToSQL()
+fmt.Println(err)
+```
+
+Output:
+```
+name is empty
+name is empty
+```
+
 ## Executing Queries
 
 To execute your query use [`goqu.Database#From`](https://godoc.org/github.com/doug-martin/goqu/#Database.From) to create your dataset
 
 <a name="scan-structs"></a>
-**[`ScanStructs`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanStructs)** 
+**[`ScanStructs`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanStructs)**
 
 Scans rows into a slice of structs
 
@@ -742,7 +785,7 @@ fmt.Printf("\n%+v", ids)
 <a name="scan-val"></a>
 [`ScanVal`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanVal)
 
-Scans a row of 1 column into a primitive value, returns false if a row wasnt found.   
+Scans a row of 1 column into a primitive value, returns false if a row wasnt found.
 
 **Note** when using the dataset a `LIMIT` of 1 is automatically applied.
 ```go
@@ -774,7 +817,7 @@ fmt.Printf("\nCount:= %d", count)
 ```
 
 <a name="pluck"></a>
-**[`Pluck`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.Pluck)** 
+**[`Pluck`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.Pluck)**
 
 Selects a single column and stores the results into a slice of primitive values
 

--- a/docs/selecting.md
+++ b/docs/selecting.md
@@ -661,14 +661,13 @@ Set an Error on a dataset:
 ```go
 func GetSelect(name string) *goqu.SelectDataset {
 
-    var ds = goqu.From("test").
-        Select(name)
+    var ds = goqu.From("test")
 
     if len(name) == 0 {
         return ds.SetError(fmt.Errorf("name is empty"))
     }
 
-    return ds
+    return ds.Select(name)
 }
 
 ```

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -429,8 +429,7 @@ Set an Error on a dataset:
 ```go
 func GetUpdate(name string, value string) *goqu.UpdateDataset {
 
-    var ds = goqu.Update("test").
-        Set(goqu.Record{name: value})
+    var ds = goqu.Update("test")
 
     if len(name) == 0 {
         return ds.SetError(fmt.Errorf("name is empty"))
@@ -440,7 +439,7 @@ func GetUpdate(name string, value string) *goqu.UpdateDataset {
         return ds.SetError(fmt.Errorf("value is empty"))
     }
 
-    return ds
+    return ds.Set(goqu.Record{name: value})
 }
 
 ```

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -10,9 +10,10 @@
   * [Order](#order)
   * [Limit](#limit)
   * [Returning](#returning)
+  * [SetError](#seterror)
   * [Executing](#executing)
-  
-<a name="create"></a>  
+
+<a name="create"></a>
 To create a [`UpdateDataset`](https://godoc.org/github.com/doug-martin/goqu/#UpdateDataset)  you can use
 
 **[`goqu.Update`](https://godoc.org/github.com/doug-martin/goqu/#Update)**
@@ -268,7 +269,7 @@ UPDATE "items" SET "address"='111 Test Addr',"name"='Test' []
 
 **NOTE** The `sqlite3` adapter does not support a multi table syntax.
 
-`Postgres` Example 
+`Postgres` Example
 
 ```go
 dialect := goqu.Dialect("postgres")
@@ -413,6 +414,52 @@ fmt.Println(sql)
 Output:
 ```
 UPDATE "test" SET "foo"='bar' RETURNING "test".*
+```
+
+<a name="seterror"></a>
+**[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#UpdateDataset.SetError)**
+
+Sometimes while building up a query with goqu you will encounter situations where certain
+preconditions are not met or some end-user contraint has been violated. While you could
+track this error case separately, goqu provides a convenient built-in mechanism to set an
+error on a dataset if one has not already been set to simplify query building.
+
+Set an Error on a dataset:
+
+```go
+func GetUpdate(name string, value string) *goqu.UpdateDataset {
+
+    var ds = goqu.Update("test").
+        Set(goqu.Record{name: value})
+
+    if len(name) == 0 {
+        return ds.SetError(fmt.Errorf("name is empty"))
+    }
+
+    if len(value) == 0 {
+        return ds.SetError(fmt.Errorf("value is empty"))
+    }
+
+    return ds
+}
+
+```
+
+This error is returned on any subsequent call to `Error` or `ToSQL`:
+
+```go
+var field, value string
+ds = GetUpdate(field, value)
+fmt.Println(ds.Error())
+
+sql, args, err = ds.ToSQL()
+fmt.Println(err)
+```
+
+Output:
+```
+name is empty
+name is empty
 ```
 
 <a name="executing"></a>

--- a/insert_dataset_test.go
+++ b/insert_dataset_test.go
@@ -438,6 +438,51 @@ func (ids *insertDatasetSuite) TestToSQL_ReturnedError() {
 	md.AssertExpectations(ids.T())
 }
 
+func (ids *insertDatasetSuite) TestSetError() {
+
+	err1 := errors.New("error #1")
+	err2 := errors.New("error #2")
+	err3 := errors.New("error #3")
+
+	// Verify initial error set/get works properly
+	md := new(mocks.SQLDialect)
+	ds := Insert("test").SetDialect(md)
+	ds = ds.SetError(err1)
+	ids.Equal(err1, ds.Error())
+	sql, args, err := ds.ToSQL()
+	ids.Empty(sql)
+	ids.Empty(args)
+	ids.Equal(err1, err)
+
+	// Repeated SetError calls on Dataset should not overwrite the original error
+	ds = ds.SetError(err2)
+	ids.Equal(err1, ds.Error())
+	sql, args, err = ds.ToSQL()
+	ids.Empty(sql)
+	ids.Empty(args)
+	ids.Equal(err1, err)
+
+	// Builder functions should not lose the error
+	ds = ds.Cols("a", "b")
+	ids.Equal(err1, ds.Error())
+	sql, args, err = ds.ToSQL()
+	ids.Empty(sql)
+	ids.Empty(args)
+	ids.Equal(err1, err)
+
+	// Deeper errors inside SQL generation should still return original error
+	c := ds.GetClauses()
+	sqlB := sb.NewSQLBuilder(false)
+	md.On("ToInsertSQL", sqlB, c).Run(func(args mock.Arguments) {
+		args.Get(0).(sb.SQLBuilder).SetError(err3)
+	}).Once()
+
+	sql, args, err = ds.ToSQL()
+	ids.Empty(sql)
+	ids.Empty(args)
+	ids.Equal(err1, err)
+}
+
 func TestInsertDataset(t *testing.T) {
 	suite.Run(t, new(insertDatasetSuite))
 }

--- a/select_dataset_test.go
+++ b/select_dataset_test.go
@@ -1465,6 +1465,51 @@ func (sds *selectDatasetSuite) TestPluck_WithPreparedStatement() {
 	sds.Equal([]string{"Bob", "Sally", "Billy"}, names)
 }
 
+func (sds *selectDatasetSuite) TestSetError() {
+
+	err1 := errors.New("error #1")
+	err2 := errors.New("error #2")
+	err3 := errors.New("error #3")
+
+	// Verify initial error set/get works properly
+	md := new(mocks.SQLDialect)
+	ds := From("test").SetDialect(md)
+	ds = ds.SetError(err1)
+	sds.Equal(err1, ds.Error())
+	sql, args, err := ds.ToSQL()
+	sds.Empty(sql)
+	sds.Empty(args)
+	sds.Equal(err1, err)
+
+	// Repeated SetError calls on Dataset should not overwrite the original error
+	ds = ds.SetError(err2)
+	sds.Equal(err1, ds.Error())
+	sql, args, err = ds.ToSQL()
+	sds.Empty(sql)
+	sds.Empty(args)
+	sds.Equal(err1, err)
+
+	// Builder functions should not lose the error
+	ds = ds.ClearWindow()
+	sds.Equal(err1, ds.Error())
+	sql, args, err = ds.ToSQL()
+	sds.Empty(sql)
+	sds.Empty(args)
+	sds.Equal(err1, err)
+
+	// Deeper errors inside SQL generation should still return original error
+	c := ds.GetClauses()
+	sqlB := sb.NewSQLBuilder(false)
+	md.On("ToInsertSQL", sqlB, c).Run(func(args mock.Arguments) {
+		args.Get(0).(sb.SQLBuilder).SetError(err3)
+	}).Once()
+
+	sql, args, err = ds.ToSQL()
+	sds.Empty(sql)
+	sds.Empty(args)
+	sds.Equal(err1, err)
+}
+
 func TestSelectDataset(t *testing.T) {
 	suite.Run(t, new(selectDatasetSuite))
 }

--- a/update_dataset_test.go
+++ b/update_dataset_test.go
@@ -436,6 +436,51 @@ func (uds *updateDatasetSuite) TestExecutor() {
 	uds.Equal(`UPDATE "items" SET "address"=?,"name"=? WHERE ("name" IS NULL)`, updateSQL)
 }
 
+func (uds *updateDatasetSuite) TestSetError() {
+
+	err1 := errors.New("error #1")
+	err2 := errors.New("error #2")
+	err3 := errors.New("error #3")
+
+	// Verify initial error set/get works properly
+	md := new(mocks.SQLDialect)
+	ds := Update("test").SetDialect(md)
+	ds = ds.SetError(err1)
+	uds.Equal(err1, ds.Error())
+	sql, args, err := ds.ToSQL()
+	uds.Empty(sql)
+	uds.Empty(args)
+	uds.Equal(err1, err)
+
+	// Repeated SetError calls on Dataset should not overwrite the original error
+	ds = ds.SetError(err2)
+	uds.Equal(err1, ds.Error())
+	sql, args, err = ds.ToSQL()
+	uds.Empty(sql)
+	uds.Empty(args)
+	uds.Equal(err1, err)
+
+	// Builder functions should not lose the error
+	ds = ds.ClearLimit()
+	uds.Equal(err1, ds.Error())
+	sql, args, err = ds.ToSQL()
+	uds.Empty(sql)
+	uds.Empty(args)
+	uds.Equal(err1, err)
+
+	// Deeper errors inside SQL generation should still return original error
+	c := ds.GetClauses()
+	sqlB := sb.NewSQLBuilder(false)
+	md.On("ToUpdateSQL", sqlB, c).Run(func(args mock.Arguments) {
+		args.Get(0).(sb.SQLBuilder).SetError(err3)
+	}).Once()
+
+	sql, args, err = ds.ToSQL()
+	uds.Empty(sql)
+	uds.Empty(args)
+	uds.Equal(err1, err)
+}
+
 func TestUpdateDataset(t *testing.T) {
 	suite.Run(t, new(updateDatasetSuite))
 }


### PR DESCRIPTION
This addresses https://github.com/doug-martin/goqu/issues/150 by
adding SetError and Error methods to each dataset. This will allow
end-user query building (e.g. users of goqu) to be able to mark a
dataset as being in a failed state via SetError and not have to track
that separately.

It only sets the error if one has not already been set. It also sets it
on the underlying SQLBuilder so that it too will know about the error
and not try to proceed with any futher query building. As such, future
calls to ToSQL will return the error as well.