### PR TITLE
exec.Scanner: New exposed scanner supports iterative scanning

### DIFF
--- a/docs/selecting.md
+++ b/docs/selecting.md
@@ -801,6 +801,38 @@ if !found{
 }
 ```
 
+<a name="Scanner"></a>
+**[`Scanner`](http://godoc.org/github.com/doug-martin/goqu/exec#Scanner)**
+
+Scanner knows how to scan rows into structs. This is usefull when dealing with
+large result sets where you can have only one item scanned in memory at one
+time.
+
+```go
+// Create a new scanner from sql.Rows.
+
+rows, _ := sql.Query(...)
+
+scanner, err := exec.Scanner(rows)
+
+for scanner.Next() {
+    scanner.ScanStruct(&myStruct)
+}
+
+// Or create a scanner from a SelectDataset.
+
+scanner, err := db.From("user").
+    Select("first_name", "last_name").
+    Executor().Scanner()
+
+for scanner.Next() {
+    myStruct := MyStruct{}
+    scanner.ScanSTruct(&myStruct)
+    
+    doSomethingWithStruct(myStruct)
+}
+```
+
 <a name="count"></a>
 **[`Count`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.Count)**
 

--- a/exec/query_executor.go
+++ b/exec/query_executor.go
@@ -87,12 +87,28 @@ func (q QueryExecutor) ScanStructsContext(ctx context.Context, i interface{}) er
 	if !util.IsSlice(val.Kind()) {
 		return errUnsupportedScanStructsType
 	}
-	scanner, err := q.rowsScanner(ctx)
+
+	elemType := util.GetSliceElementType(val)
+
+	scanner, err := q.ScannerContext(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = scanner.ScanStructs(i)
-	return err
+
+	defer scanner.Close()
+
+	for scanner.Next() {
+		row := reflect.New(elemType)
+
+		err = scanner.ScanStruct(row.Interface())
+		if err != nil {
+			return err
+		}
+
+		util.AppendSliceElement(val, row)
+	}
+
+	return scanner.Err()
 }
 
 // This will execute the SQL and fill out the struct with the fields returned.
@@ -132,11 +148,24 @@ func (q QueryExecutor) ScanStructContext(ctx context.Context, i interface{}) (bo
 	if !util.IsStruct(val.Kind()) {
 		return false, errUnsupportedScanStructType
 	}
-	scanner, err := q.rowsScanner(ctx)
+
+	scanner, err := q.ScannerContext(ctx)
 	if err != nil {
 		return false, err
 	}
-	return scanner.ScanStructs(i)
+
+	defer scanner.Close()
+
+	if scanner.Next() {
+		err = scanner.ScanStruct(i)
+		if err != nil {
+			return true, err
+		}
+
+		return true, scanner.Err()
+	}
+
+	return false, scanner.Err()
 }
 
 // This will execute the SQL and append results to the slice.
@@ -166,12 +195,28 @@ func (q QueryExecutor) ScanValsContext(ctx context.Context, i interface{}) error
 	if !util.IsSlice(val.Kind()) {
 		return errUnsupportedScanValsType
 	}
-	scanner, err := q.rowsScanner(ctx)
+
+	elemType := util.GetSliceElementType(val)
+
+	scanner, err := q.ScannerContext(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = scanner.ScanVals(i)
-	return err
+
+	defer scanner.Close()
+
+	for scanner.Next() {
+		row := reflect.New(elemType)
+
+		err = scanner.ScanVal(row.Interface())
+		if err != nil {
+			return err
+		}
+
+		util.AppendSliceElement(val, row)
+	}
+
+	return scanner.Err()
 }
 
 // This will execute the SQL and set the value of the primitive. This method will return false if no record is found.
@@ -215,14 +260,33 @@ func (q QueryExecutor) ScanValContext(ctx context.Context, i interface{}) (bool,
 			return false, errScanValNonSlice
 		}
 	}
-	rows, err := q.QueryContext(ctx)
+
+	scanner, err := q.ScannerContext(ctx)
 	if err != nil {
 		return false, err
 	}
-	return NewScanner(rows).ScanVal(i)
+
+	defer scanner.Close()
+
+	if scanner.Next() {
+		err = scanner.ScanVal(i)
+		if err != nil {
+			return true, err
+		}
+
+		return true, scanner.Err()
+	}
+
+	return false, scanner.Err()
 }
 
-func (q QueryExecutor) rowsScanner(ctx context.Context) (Scanner, error) {
+// Scanner will return a Scanner that can be used for manually scanning rows.
+func (q QueryExecutor) Scanner() (Scanner, error) {
+	return q.ScannerContext(context.Background())
+}
+
+// ScannerContext will return a Scanner that can be used for manually scanning rows.
+func (q QueryExecutor) ScannerContext(ctx context.Context) (Scanner, error) {
 	rows, err := q.QueryContext(ctx)
 	if err != nil {
 		return nil, err

--- a/exec/scanner.go
+++ b/exec/scanner.go
@@ -10,13 +10,19 @@ import (
 )
 
 type (
+	// Scanner knows how to scan sql.Rows into structs.
 	Scanner interface {
-		ScanStructs(i interface{}) (bool, error)
-		ScanVals(i interface{}) (bool, error)
-		ScanVal(i interface{}) (found bool, err error)
+		Next() bool
+		ScanStruct(i interface{}) error
+		ScanVal(i interface{}) error
+		Close() error
+		Err() error
 	}
+
 	scanner struct {
-		rows *sql.Rows
+		rows      *sql.Rows
+		columnMap util.ColumnMap
+		columns   []string
 	}
 )
 
@@ -24,109 +30,79 @@ func unableToFindFieldError(col string) error {
 	return errors.New(`unable to find corresponding field to column "%s" returned by query`, col)
 }
 
+// NewScanner returns a scanner that can be used for scanning rows into structs.
 func NewScanner(rows *sql.Rows) Scanner {
 	return &scanner{rows: rows}
 }
 
-// This will execute the SQL and append results to the slice
-//    var myStructs []MyStruct
-//    if err := From("test").ScanStructs(&myStructs); err != nil{
-//        panic(err.Error()
-//    }
-//    //use your structs
-//
-//
-// i: A pointer to a slice of structs.
-func (q *scanner) ScanStructs(i interface{}) (found bool, err error) {
-	defer q.rows.Close()
-	cm, err := util.GetColumnMap(i)
-	if err != nil {
-		return found, err
-	}
-	var results []map[string]interface{}
-	columns, err := q.rows.Columns()
-	if err != nil {
-		return false, err
-	}
-	for q.rows.Next() {
-		record, err := q.scanIntoRecord(columns, cm)
+// Next prepares the next row for Scanning. See sql.Rows#Next for more
+// information.
+func (it *scanner) Next() bool {
+	return it.rows.Next()
+}
+
+// Err returns the error, if any that was encountered during iteration. See
+// sql.Rows#Err for more information.
+func (it *scanner) Err() error {
+	return it.rows.Err()
+}
+
+// ScanStruct will scan the current row into i.
+func (it *scanner) ScanStruct(i interface{}) error {
+	// Setup columnMap and columns, but only once.
+	if it.columnMap == nil || it.columns == nil {
+		cm, err := util.GetColumnMap(i)
 		if err != nil {
-			return found, err
+			return err
 		}
 
-		results = append(results, record)
-	}
-	if q.rows.Err() != nil {
-		return false, q.rows.Err()
-	}
-	if len(results) > 0 {
-		found = true
-		util.AssignStructVals(i, results, cm)
-	}
-	return found, nil
-}
-
-// This will execute the SQL and append results to the slice.
-//    var ids []uint32
-//    if err := From("test").Select("id").ScanVals(&ids); err != nil{
-//        panic(err.Error()
-//    }
-//
-// i: Takes a pointer to a slice of primitive values.
-func (q *scanner) ScanVals(i interface{}) (found bool, err error) {
-	defer q.rows.Close()
-	val := reflect.Indirect(reflect.ValueOf(i))
-	t, _, isSliceOfPointers := util.GetTypeInfo(i, val)
-	for q.rows.Next() {
-		found = true
-		row := reflect.New(t)
-		if err = q.rows.Scan(row.Interface()); err != nil {
-			return found, err
+		cols, err := it.rows.Columns()
+		if err != nil {
+			return err
 		}
-		if isSliceOfPointers {
-			val.Set(reflect.Append(val, row))
-		} else {
-			val.Set(reflect.Append(val, reflect.Indirect(row)))
-		}
-	}
-	return found, q.rows.Err()
-}
 
-// This will execute the SQL and append results to the slice.
-//    var ids []uint32
-//    if err := From("test").Select("id").ScanVals(&ids); err != nil{
-//        panic(err.Error()
-//    }
-//
-// i: Takes a pointer to a slice of primitive values.
-func (q *scanner) ScanVal(i interface{}) (found bool, err error) {
-	defer q.rows.Close()
-	for q.rows.Next() {
-		found = true
-		if err = q.rows.Scan(i); err != nil {
-			return false, err
-		}
+		it.columnMap = cm
+		it.columns = cols
 	}
-	return found, q.rows.Err()
-}
 
-func (q *scanner) scanIntoRecord(columns []string, cm util.ColumnMap) (record exp.Record, err error) {
-	scans := make([]interface{}, len(columns))
-	for i, col := range columns {
-		data, ok := cm[col]
+	scans := make([]interface{}, len(it.columns))
+	for idx, col := range it.columns {
+		data, ok := it.columnMap[col]
 		switch {
 		case !ok:
-			return record, unableToFindFieldError(col)
+			return unableToFindFieldError(col)
 		default:
-			scans[i] = reflect.New(data.GoType).Interface()
+			scans[idx] = reflect.New(data.GoType).Interface()
 		}
 	}
-	if err := q.rows.Scan(scans...); err != nil {
-		return record, err
+
+	err := it.rows.Scan(scans...)
+	if err != nil {
+		return err
 	}
-	record = exp.Record{}
-	for index, col := range columns {
+
+	record := exp.Record{}
+	for index, col := range it.columns {
 		record[col] = scans[index]
 	}
-	return record, nil
+
+	util.AssignStructVals(i, record, it.columnMap)
+
+	return it.Err()
+}
+
+// ScanVal will scan the current row and column into i.
+func (it *scanner) ScanVal(i interface{}) error {
+	err := it.rows.Scan(i)
+	if err != nil {
+		return err
+	}
+
+	return it.Err()
+}
+
+// Close closes the Rows, preventing further enumeration. See sql.Rows#Close
+// for more info.
+func (it *scanner) Close() error {
+	return it.rows.Close()
 }

--- a/internal/util/reflect_test.go
+++ b/internal/util/reflect_test.go
@@ -446,14 +446,13 @@ func (rt *reflectTest) TestAssignStructVals_withStruct() {
 	var ts TestStruct
 	cm, err := GetColumnMap(&ts)
 	rt.NoError(err)
-	data := []map[string]interface{}{
-		{
-			"str":    "string",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": sql.NullString{String: "null_str", Valid: true},
-		},
+	data := map[string]interface{}{
+		"str":    "string",
+		"int":    int64(10),
+		"bool":   true,
+		"valuer": sql.NullString{String: "null_str", Valid: true},
 	}
+
 	AssignStructVals(&ts, data, cm)
 	rt.Equal(ts, TestStruct{
 		Str:    "string",
@@ -474,13 +473,11 @@ func (rt *reflectTest) TestAssignStructVals_withStructWithPointerVals() {
 	cm, err := GetColumnMap(&ts)
 	rt.NoError(err)
 	ns := &sql.NullString{String: "null_str1", Valid: true}
-	data := []map[string]interface{}{
-		{
-			"str":    "string",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": &ns,
-		},
+	data := map[string]interface{}{
+		"str":    "string",
+		"int":    int64(10),
+		"bool":   true,
+		"valuer": &ns,
 	}
 	AssignStructVals(&ts, data, cm)
 	rt.Equal(ts, TestStruct{
@@ -506,13 +503,11 @@ func (rt *reflectTest) TestAssignStructVals_withStructWithEmbeddedStruct() {
 	cm, err := GetColumnMap(&ts)
 	rt.NoError(err)
 	ns := &sql.NullString{String: "null_str1", Valid: true}
-	data := []map[string]interface{}{
-		{
-			"str":    "string",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": &ns,
-		},
+	data := map[string]interface{}{
+		"str":    "string",
+		"int":    int64(10),
+		"bool":   true,
+		"valuer": &ns,
 	}
 	AssignStructVals(&ts, data, cm)
 	rt.Equal(ts, TestStruct{
@@ -538,13 +533,11 @@ func (rt *reflectTest) TestAssignStructVals_withStructWithEmbeddedStructPointer(
 	cm, err := GetColumnMap(&ts)
 	rt.NoError(err)
 	ns := &sql.NullString{String: "null_str1", Valid: true}
-	data := []map[string]interface{}{
-		{
-			"str":    "string",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": &ns,
-		},
+	data := map[string]interface{}{
+		"str":    "string",
+		"int":    int64(10),
+		"bool":   true,
+		"valuer": &ns,
 	}
 	AssignStructVals(&ts, data, cm)
 	rt.Equal(ts, TestStruct{
@@ -552,228 +545,6 @@ func (rt *reflectTest) TestAssignStructVals_withStructWithEmbeddedStructPointer(
 		Int:            10,
 		Bool:           true,
 		Valuer:         ns,
-	})
-}
-
-func (rt *reflectTest) TestAssignStructVals_withSlice() {
-
-	type TestStruct struct {
-		Str    string
-		Int    int64
-		Bool   bool
-		Valuer sql.NullString
-	}
-	var ts []TestStruct
-	cm, err := GetColumnMap(&ts)
-	rt.NoError(err)
-	data := []map[string]interface{}{
-		{
-			"str":    "string1",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": sql.NullString{String: "null_str1", Valid: true},
-		},
-		{
-			"str":    "string2",
-			"int":    int64(20),
-			"bool":   false,
-			"valuer": sql.NullString{String: "null_str2", Valid: true},
-		},
-	}
-	AssignStructVals(&ts, data, cm)
-	rt.Equal(ts, []TestStruct{
-		{
-			Str:    "string1",
-			Int:    10,
-			Bool:   true,
-			Valuer: sql.NullString{String: "null_str1", Valid: true},
-		},
-		{
-			Str:    "string2",
-			Int:    20,
-			Bool:   false,
-			Valuer: sql.NullString{String: "null_str2", Valid: true},
-		},
-	})
-}
-
-func (rt *reflectTest) TestAssignStructVals_withSliceOfPointers() {
-
-	type TestStruct struct {
-		Str    string
-		Int    int64
-		Bool   bool
-		Valuer sql.NullString
-	}
-	var ts []*TestStruct
-	cm, err := GetColumnMap(&ts)
-	rt.NoError(err)
-	data := []map[string]interface{}{
-		{
-			"str":    "string1",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": sql.NullString{String: "null_str1", Valid: true},
-		},
-		{
-			"str":    "string2",
-			"int":    int64(20),
-			"bool":   false,
-			"valuer": sql.NullString{String: "null_str2", Valid: true},
-		},
-	}
-	AssignStructVals(&ts, data, cm)
-	rt.Equal(ts, []*TestStruct{
-		{
-			Str:    "string1",
-			Int:    10,
-			Bool:   true,
-			Valuer: sql.NullString{String: "null_str1", Valid: true},
-		},
-		{
-			Str:    "string2",
-			Int:    20,
-			Bool:   false,
-			Valuer: sql.NullString{String: "null_str2", Valid: true},
-		},
-	})
-}
-
-func (rt *reflectTest) TestAssignStructVals_withSliceOfStructsWithPointerVals() {
-
-	type TestStruct struct {
-		Str    string
-		Int    int64
-		Bool   bool
-		Valuer *sql.NullString
-	}
-	var ts []TestStruct
-	cm, err := GetColumnMap(&ts)
-	rt.NoError(err)
-	ns1 := &sql.NullString{String: "null_str1", Valid: true}
-	ns2 := &sql.NullString{String: "null_str2", Valid: true}
-	data := []map[string]interface{}{
-		{
-			"str":    "string1",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": &ns1,
-		},
-		{
-			"str":    "string2",
-			"int":    int64(20),
-			"bool":   false,
-			"valuer": &ns2,
-		},
-	}
-	AssignStructVals(&ts, data, cm)
-	rt.Equal(ts, []TestStruct{
-		{
-			Str:    "string1",
-			Int:    10,
-			Bool:   true,
-			Valuer: ns1,
-		},
-		{
-			Str:    "string2",
-			Int:    20,
-			Bool:   false,
-			Valuer: ns2,
-		},
-	})
-}
-
-func (rt *reflectTest) TestAssignStructVals_withSliceofStructsWithEmbeddedStruct() {
-
-	type EmbeddedStruct struct {
-		Str string
-	}
-	type TestStruct struct {
-		EmbeddedStruct
-		Int    int64
-		Bool   bool
-		Valuer *sql.NullString
-	}
-	var ts []TestStruct
-	cm, err := GetColumnMap(&ts)
-	rt.NoError(err)
-	ns1 := &sql.NullString{String: "null_str1", Valid: true}
-	ns2 := &sql.NullString{String: "null_str2", Valid: true}
-	data := []map[string]interface{}{
-		{
-			"str":    "string1",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": &ns1,
-		},
-		{
-			"str":    "string2",
-			"int":    int64(20),
-			"bool":   false,
-			"valuer": &ns2,
-		},
-	}
-	AssignStructVals(&ts, data, cm)
-	rt.Equal(ts, []TestStruct{
-		{
-			EmbeddedStruct: EmbeddedStruct{Str: "string1"},
-			Int:            10,
-			Bool:           true,
-			Valuer:         ns1,
-		},
-		{
-			EmbeddedStruct: EmbeddedStruct{Str: "string2"},
-			Int:            20,
-			Bool:           false,
-			Valuer:         ns2,
-		},
-	})
-}
-
-func (rt *reflectTest) TestAssignStructVals_withSliceofStructsWithEmbeddedStructPointer() {
-
-	type EmbeddedStruct struct {
-		Str string
-	}
-	type TestStruct struct {
-		*EmbeddedStruct
-		Int    int64
-		Bool   bool
-		Valuer *sql.NullString
-	}
-	var ts []TestStruct
-	cm, err := GetColumnMap(&ts)
-	rt.NoError(err)
-	ns1 := &sql.NullString{String: "null_str1", Valid: true}
-	ns2 := &sql.NullString{String: "null_str2", Valid: true}
-	data := []map[string]interface{}{
-		{
-			"str":    "string1",
-			"int":    int64(10),
-			"bool":   true,
-			"valuer": &ns1,
-		},
-		{
-			"str":    "string2",
-			"int":    int64(20),
-			"bool":   false,
-			"valuer": &ns2,
-		},
-	}
-	AssignStructVals(&ts, data, cm)
-	rt.Equal(ts, []TestStruct{
-		{
-			EmbeddedStruct: &EmbeddedStruct{Str: "string1"},
-			Int:            10,
-			Bool:           true,
-			Valuer:         ns1,
-		},
-		{
-			EmbeddedStruct: &EmbeddedStruct{Str: "string2"},
-			Int:            20,
-			Bool:           false,
-			Valuer:         ns2,
-		},
 	})
 }
 
@@ -1094,6 +865,53 @@ func (rt *reflectTest) TestSafeGetFieldByIndex() {
 	f, isAvailable = SafeGetFieldByIndex(v, []int{})
 	rt.True(isAvailable)
 	rt.Equal(v, f)
+}
+
+func (rt *reflectTest) TestGetSliceElementType() {
+	type MyStruct struct{}
+
+	tests := []struct {
+		slice interface{}
+		want  reflect.Type
+	}{
+		{
+			slice: []int{},
+			want:  reflect.TypeOf(1),
+		},
+		{
+			slice: []*int{},
+			want:  reflect.TypeOf(1),
+		},
+		{
+			slice: []MyStruct{},
+			want:  reflect.TypeOf(MyStruct{}),
+		},
+		{
+			slice: []*MyStruct{},
+			want:  reflect.TypeOf(MyStruct{}),
+		},
+	}
+
+	for _, tt := range tests {
+		sliceVal := reflect.ValueOf(tt.slice)
+		elementType := GetSliceElementType(sliceVal)
+
+		rt.Equal(tt.want, elementType)
+	}
+}
+
+func (rt *reflectTest) TestAppendSliceElement() {
+	type MyStruct struct{}
+
+	sliceVal := reflect.Indirect(reflect.ValueOf(&[]MyStruct{}))
+	AppendSliceElement(sliceVal, reflect.ValueOf(&MyStruct{}))
+
+	rt.Equal([]MyStruct{{}}, sliceVal.Interface())
+
+	sliceVal = reflect.Indirect(reflect.ValueOf(&[]*MyStruct{}))
+	AppendSliceElement(sliceVal, reflect.ValueOf(&MyStruct{}))
+
+	rt.Equal([]*MyStruct{{}}, sliceVal.Interface())
 }
 
 func TestReflectSuite(t *testing.T) {

--- a/select_dataset_example_test.go
+++ b/select_dataset_example_test.go
@@ -1277,3 +1277,83 @@ func ExampleSelectDataset_Pluck() {
 	// Output:
 	// LastNames := [Yukon Yukon Yukon Doe]
 }
+
+func ExampleSelectDataset_Executor_scanner_scanstruct() {
+	type User struct {
+		FirstName string `db:"first_name"`
+		LastName  string `db:"last_name"`
+	}
+	db := getDb()
+
+	rows, err := db.From("goqu_user").
+		Select("first_name", "last_name").
+		Where(goqu.Ex{
+			"last_name": "Yukon",
+		}).Executor().Scanner()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		u := User{}
+
+		err = rows.ScanStruct(&u)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
+		fmt.Printf("\n%+v", u)
+	}
+
+	if rows.Err() != nil {
+		fmt.Println(rows.Err().Error())
+	}
+
+	// Output:
+	// {FirstName:Bob LastName:Yukon}
+	// {FirstName:Sally LastName:Yukon}
+	// {FirstName:Vinita LastName:Yukon}
+}
+
+func ExampleSelectDataset_Executor_scanner_scanval() {
+	db := getDb()
+
+	rows, err := db.From("goqu_user").
+		Select("first_name").
+		Where(goqu.Ex{
+			"last_name": "Yukon",
+		}).Executor().Scanner()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		name := ""
+
+		err = rows.ScanVal(&name)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
+		fmt.Println(name)
+	}
+
+	if rows.Err() != nil {
+		fmt.Println(rows.Err().Error())
+	}
+
+	// Output:
+	// Bob
+	// Sally
+	// Vinita
+}


### PR DESCRIPTION
A Scanner that is modeled after sql.Rows Next and Scan. This can be used when scanning one item at a time for better memory efficiency on large result sets.

I'm a bit unsure about the `db.From().Select().Executor().Scanner()` way of getting it when coming from a `SelectDataset` but I think that this wouldn't be used so often as to warrant a method directly on the `SelectDataset`.

Let me know what you think!