### PR TITLE
[WIP] Embedded Value support

### DIFF
--- a/exp/record.go
+++ b/exp/record.go
@@ -52,13 +52,19 @@ func addFieldToRecord(r Record, val reflect.Value, f util.ColumnData) Record {
 	if !isAvailable {
 		return r
 	}
-	switch {
-	case f.DefaultIfEmpty && util.IsEmptyValue(v):
-		r[f.ColumnName] = Default()
-	case v.IsValid():
-		r[f.ColumnName] = v.Interface()
-	default:
-		r[f.ColumnName] = reflect.Zero(f.GoType).Interface()
+	if !(f.Omitempty && util.IsEmptyValue(v)) {
+		switch {
+		case f.DefaultIfEmpty && util.IsEmptyValue(v):
+			r[f.ColumnName] = Default()
+		case v.IsValid():
+			if f.Embed {
+				r[f.ColumnName] = util.NewEmbedder(v.Interface())
+			} else {
+				r[f.ColumnName] = v.Interface()
+			}
+		default:
+			r[f.ColumnName] = reflect.Zero(f.GoType).Interface()
+		}
 	}
 	return r
 }

--- a/internal/tag/tags.go
+++ b/internal/tag/tags.go
@@ -17,13 +17,7 @@ type Options []string
 func New(tagName string, st reflect.StructTag) Tag {
 	return Parse(st.Get(tagName))
 }
-func (t Tag) Values() []string {
-	tags := strings.Split(t.tag, ",")
-	for i, tag := range tags {
-		tags[i] = strings.TrimSpace(tag)
-	}
-	return tags
-}
+
 func Parse(tag string) Tag {
 	var t Tag
 	t.tag = tag
@@ -65,6 +59,16 @@ func (t Tag) IsEmpty() bool {
 
 func (t Tag) Has(optionName string) bool {
 	return t.options.Contains(optionName)
+}
+func (t Tag) Values() Options {
+	return t.values()
+}
+func (t Tag) values() []string {
+	tags := strings.Split(t.tag, ",")
+	for i, tag := range tags {
+		tags[i] = strings.TrimSpace(tag)
+	}
+	return tags
 }
 
 // Contains reports whether a comma-separated list of options

--- a/internal/tag/tags.go
+++ b/internal/tag/tags.go
@@ -7,17 +7,64 @@ import (
 
 // tagOptions is the string following a comma in a struct field's "json"
 // tag, or the empty string. It does not include the leading comma.
-type Options string
+type Tag struct {
+	tag     string
+	name    Name
+	options Options
+}
+type Name string
+type Options []string
 
-func New(tagName string, st reflect.StructTag) Options {
-	return Options(st.Get(tagName))
+func New(tagName string, st reflect.StructTag) Tag {
+	return Parse(st.Get(tagName))
+}
+func (t Tag) Values() []string {
+	tags := strings.Split(t.tag, ",")
+	for i, tag := range tags {
+		tags[i] = strings.TrimSpace(tag)
+	}
+	return tags
+}
+func Parse(tag string) Tag {
+	var t Tag
+	t.tag = tag
+	tags := strings.Split(tag, ",")
+	for i, v := range tags {
+		tags[i] = strings.TrimSpace(v)
+	}
+	switch len(tags) {
+	case 0:
+		t.name = ""
+		t.options = nil
+	case 1:
+		t.name = Name(tags[0])
+		t.options = nil
+	default:
+		t.name = Name(tags[0])
+		t.options = tags[1:]
+	}
+	return t
+}
+func (t Tag) Name() Name {
+	return t.name
 }
 
-func (o Options) Values() []string {
-	if string(o) == "" {
-		return []string{}
+func (t Tag) IsEmpty() bool {
+	return len(t.tag) == 0
+}
+
+func (t Tag) Has(optionName string) bool {
+	return t.options.Contains(optionName)
+}
+
+func (n Name) IsEmpty() bool {
+	if n != "" {
+		return false
 	}
-	return strings.Split(string(o), ",")
+	return true
+}
+func (n Name) String() string {
+	return string(n)
 }
 
 // Contains reports whether a comma-separated list of options
@@ -27,25 +74,13 @@ func (o Options) Contains(optionName string) bool {
 	if o.IsEmpty() {
 		return false
 	}
-	values := o.Values()
-	for _, s := range values {
+	for _, s := range o {
 		if s == optionName {
 			return true
 		}
 	}
 	return false
 }
-
-// Contains reports whether a comma-separated list of options
-// contains a particular substr flag. substr must be surrounded by a
-// string boundary or commas.
-func (o Options) Equals(val string) bool {
-	if len(o) == 0 {
-		return false
-	}
-	return string(o) == val
-}
-
 func (o Options) IsEmpty() bool {
 	return len(o) == 0
 }

--- a/internal/tag/tags.go
+++ b/internal/tag/tags.go
@@ -9,10 +9,9 @@ import (
 // tag, or the empty string. It does not include the leading comma.
 type Tag struct {
 	tag     string
-	name    Name
+	name    string
 	options Options
 }
-type Name string
 type Options []string
 
 func New(tagName string, st reflect.StructTag) Tag {
@@ -37,34 +36,35 @@ func Parse(tag string) Tag {
 		t.name = ""
 		t.options = nil
 	case 1:
-		t.name = Name(tags[0])
+		t.name = tags[0]
 		t.options = nil
 	default:
-		t.name = Name(tags[0])
+		t.name = tags[0]
 		t.options = tags[1:]
 	}
 	return t
 }
-func (t Tag) Name() Name {
+func (t Tag) Name() string {
 	return t.name
 }
-
+func (t Tag) IsNamed() bool {
+	if t.name != "" {
+		return true
+	}
+	return false
+}
+func (t Tag) Skip() bool {
+	if t.name == "-" {
+		return true
+	}
+	return false
+}
 func (t Tag) IsEmpty() bool {
 	return len(t.tag) == 0
 }
 
 func (t Tag) Has(optionName string) bool {
 	return t.options.Contains(optionName)
-}
-
-func (n Name) IsEmpty() bool {
-	if n != "" {
-		return false
-	}
-	return true
-}
-func (n Name) String() string {
-	return string(n)
 }
 
 // Contains reports whether a comma-separated list of options

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,408 @@
+// simple port of the PQ slice/array type library
+
+package types
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// BoolArray represents a one-dimensional array of the PostgreSQL boolean type.
+type BoolArray []bool
+
+// Scan implements the sql.Scanner interface.
+func (a *BoolArray) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("cannot convert %T to BoolArray", src)
+}
+
+func (a *BoolArray) scanBytes(src []byte) error {
+	elems, err := scanLinearArray(src, []byte{','}, "BoolArray")
+	if err != nil {
+		return err
+	}
+	if *a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(BoolArray, len(elems))
+		for i, v := range elems {
+			if len(v) != 1 {
+				return fmt.Errorf("could not parse boolean array index %d: invalid boolean %q", i, v)
+			}
+			switch v[0] {
+			case 't':
+				b[i] = true
+			case 'f':
+				b[i] = false
+			default:
+				return fmt.Errorf("could not parse boolean array index %d: invalid boolean %q", i, v)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (a BoolArray) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be exactly two curly brackets, N bytes of values,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1+2*n)
+
+		for i := 0; i < n; i++ {
+			b[2*i] = ','
+			if a[i] {
+				b[1+2*i] = 't'
+			} else {
+				b[1+2*i] = 'f'
+			}
+		}
+
+		b[0] = '{'
+		b[2*n] = '}'
+
+		return string(b), nil
+	}
+
+	return "{}", nil
+}
+
+// Float64Array represents a one-dimensional array of the PostgreSQL double
+// precision type.
+type Float64Array []float64
+
+// Scan implements the sql.Scanner interface.
+func (a *Float64Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("cannot convert %T to Float64Array", src)
+}
+
+func (a *Float64Array) scanBytes(src []byte) error {
+	elems, err := scanLinearArray(src, []byte{','}, "Float64Array")
+	if err != nil {
+		return err
+	}
+	if *a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(Float64Array, len(elems))
+		for i, v := range elems {
+			if b[i], err = strconv.ParseFloat(string(v), 64); err != nil {
+				return fmt.Errorf("parsing array element index %d: %v", i, err)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (a Float64Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be at least two curly brackets, N bytes of values,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1, 1+2*n)
+		b[0] = '{'
+
+		b = strconv.AppendFloat(b, a[0], 'f', -1, 64)
+		for i := 1; i < n; i++ {
+			b = append(b, ',')
+			b = strconv.AppendFloat(b, a[i], 'f', -1, 64)
+		}
+
+		return string(append(b, '}')), nil
+	}
+
+	return "{}", nil
+}
+
+// Int64Array represents a one-dimensional array of the PostgreSQL integer types.
+type Int64Array []int64
+
+// Scan implements the sql.Scanner interface.
+func (a *Int64Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("cannot convert %T to Int64Array", src)
+}
+
+func (a *Int64Array) scanBytes(src []byte) error {
+	elems, err := scanLinearArray(src, []byte{','}, "Int64Array")
+	if err != nil {
+		return err
+	}
+	if *a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(Int64Array, len(elems))
+		for i, v := range elems {
+			if b[i], err = strconv.ParseInt(string(v), 10, 64); err != nil {
+				return fmt.Errorf("parsing array element index %d: %v", i, err)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (a Int64Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be at least two curly brackets, N bytes of values,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1, 1+2*n)
+		b[0] = '{'
+
+		b = strconv.AppendInt(b, a[0], 10)
+		for i := 1; i < n; i++ {
+			b = append(b, ',')
+			b = strconv.AppendInt(b, a[i], 10)
+		}
+
+		return string(append(b, '}')), nil
+	}
+
+	return "{}", nil
+}
+
+// StringArray represents a one-dimensional array of the PostgreSQL character types.
+type StringArray []string
+
+// Scan implements the sql.Scanner interface.
+func (a *StringArray) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("cannot convert %T to StringArray", src)
+}
+
+func (a *StringArray) scanBytes(src []byte) error {
+	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
+	if err != nil {
+		return err
+	}
+	if *a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(StringArray, len(elems))
+		for i, v := range elems {
+			if b[i] = string(v); v == nil {
+				return fmt.Errorf("parsing array element index %d: cannot convert nil to string", i)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (a StringArray) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be at least two curly brackets, 2*N bytes of quotes,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1, 1+3*n)
+		b[0] = '{'
+
+		b = appendArrayQuotedBytes(b, []byte(a[0]))
+		for i := 1; i < n; i++ {
+			b = append(b, ',')
+			b = appendArrayQuotedBytes(b, []byte(a[i]))
+		}
+
+		return string(append(b, '}')), nil
+	}
+
+	return "{}", nil
+}
+
+func appendArrayQuotedBytes(b, v []byte) []byte {
+	b = append(b, '"')
+	for {
+		i := bytes.IndexAny(v, `"\`)
+		if i < 0 {
+			b = append(b, v...)
+			break
+		}
+		if i > 0 {
+			b = append(b, v[:i]...)
+		}
+		b = append(b, '\\', v[i])
+		v = v[i+1:]
+	}
+	return append(b, '"')
+}
+
+// parseArray extracts the dimensions and elements of an array represented in
+// text format. Only representations emitted by the backend are supported.
+// Notably, whitespace around brackets and delimiters is significant, and NULL
+// is case-sensitive.
+//
+// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
+	var depth, i int
+
+	if len(src) < 1 || src[0] != '{' {
+		return nil, nil, fmt.Errorf("unable to parse array; expected %q at offset %d", '{', 0)
+	}
+
+Open:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			depth++
+			i++
+		case '}':
+			elems = make([][]byte, 0)
+			goto Close
+		default:
+			break Open
+		}
+	}
+	dims = make([]int, i)
+
+Element:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			if depth == len(dims) {
+				break Element
+			}
+			depth++
+			dims[depth-1] = 0
+			i++
+		case '"':
+			var elem = []byte{}
+			var escape bool
+			for i++; i < len(src); i++ {
+				if escape {
+					elem = append(elem, src[i])
+					escape = false
+				} else {
+					switch src[i] {
+					default:
+						elem = append(elem, src[i])
+					case '\\':
+						escape = true
+					case '"':
+						elems = append(elems, elem)
+						i++
+						break Element
+					}
+				}
+			}
+		default:
+			for start := i; i < len(src); i++ {
+				if bytes.HasPrefix(src[i:], del) || src[i] == '}' {
+					elem := src[start:i]
+					if len(elem) == 0 {
+						return nil, nil, fmt.Errorf("unable to parse array; unexpected %q at offset %d", src[i], i)
+					}
+					if bytes.Equal(elem, []byte("NULL")) {
+						elem = nil
+					}
+					elems = append(elems, elem)
+					break Element
+				}
+			}
+		}
+	}
+
+	for i < len(src) {
+		if bytes.HasPrefix(src[i:], del) && depth > 0 {
+			dims[depth-1]++
+			i += len(del)
+			goto Element
+		} else if src[i] == '}' && depth > 0 {
+			dims[depth-1]++
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf("unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+
+Close:
+	for i < len(src) {
+		if src[i] == '}' && depth > 0 {
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf("unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+	if depth > 0 {
+		err = fmt.Errorf("unable to parse array; expected %q at offset %d", '}', i)
+	}
+	if err == nil {
+		for _, d := range dims {
+			if (len(elems) % d) != 0 {
+				err = fmt.Errorf("multidimensional arrays must have elements with matching dimensions")
+			}
+		}
+	}
+	return
+}
+
+func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
+	dims, elems, err := parseArray(src, del)
+	if err != nil {
+		return nil, err
+	}
+	if len(dims) > 1 {
+		return nil, fmt.Errorf("cannot convert ARRAY%s to %s", strings.Replace(fmt.Sprint(dims), " ", "][", -1), typ)
+	}
+	return elems, err
+}

--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -269,13 +269,13 @@ func createColumnMap(t reflect.Type, fieldIndex []int, prefixes []string) Column
 				}
 			} else if f.PkgPath == "" {
 				// if PkgPath is empty then it is an exported field
-
+				goquTag := tag.New("goqu", f.Tag)
 				columnName = strings.Join(append(prefixes, columnName), ".")
 				cm[columnName] = ColumnData{
 					ColumnName:     columnName,
-					ShouldInsert:   !dbTag.Has(skipInsertTagName),
-					ShouldUpdate:   !dbTag.Has(skipUpdateTagName),
-					DefaultIfEmpty: dbTag.Has(defaultIfEmptyTagName),
+					ShouldInsert:   !(dbTag.Has(skipInsertTagName) || goquTag.Values().Contains(skipInsertTagName)),
+					ShouldUpdate:   !(dbTag.Has(skipUpdateTagName) || goquTag.Values().Contains(skipUpdateTagName)),
+					DefaultIfEmpty: dbTag.Has(defaultIfEmptyTagName) || goquTag.Values().Contains(defaultIfEmptyTagName),
 					Omitempty:      dbTag.Has(omitEmptyTagName),
 					Embed:          dbTag.Has(embedTagName),
 					FieldIndex:     append(fieldIndex, f.Index...),

--- a/internal/util/reflect_test.go
+++ b/internal/util/reflect_test.go
@@ -961,7 +961,33 @@ func (rt *reflectTest) TestGetColumnMap_withStruct() {
 		"valuer": {ColumnName: "valuer", FieldIndex: []int{3}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
+func (rt *reflectTest) TestGetColumnMap_withStructGoquTags() {
 
+	type TestStruct struct {
+		Str    string `goqu:"skipinsert,skipupdate"`
+		Int    int64  `goqu:"skipinsert"`
+		Bool   bool   `goqu:"skipupdate"`
+		Empty  bool   `goqu:"defaultifempty"`
+		Valuer *sql.NullString
+	}
+	var ts TestStruct
+	cm, err := GetColumnMap(&ts)
+	rt.NoError(err)
+	rt.Equal(ColumnMap{
+		"str":  {ColumnName: "str", FieldIndex: []int{0}, ShouldInsert: false, ShouldUpdate: false, GoType: reflect.TypeOf("")},
+		"int":  {ColumnName: "int", FieldIndex: []int{1}, ShouldInsert: false, ShouldUpdate: true, GoType: reflect.TypeOf(int64(1))},
+		"bool": {ColumnName: "bool", FieldIndex: []int{2}, ShouldInsert: true, ShouldUpdate: false, GoType: reflect.TypeOf(true)},
+		"empty": {
+			ColumnName:     "empty",
+			FieldIndex:     []int{3},
+			ShouldInsert:   true,
+			ShouldUpdate:   true,
+			DefaultIfEmpty: true,
+			GoType:         reflect.TypeOf(true),
+		},
+		"valuer": {ColumnName: "valuer", FieldIndex: []int{4}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
+	}, cm)
+}
 func (rt *reflectTest) TestGetColumnMap_withStructDBTags() {
 
 	type TestStruct struct {

--- a/internal/util/reflect_test.go
+++ b/internal/util/reflect_test.go
@@ -962,13 +962,13 @@ func (rt *reflectTest) TestGetColumnMap_withStruct() {
 	}, cm)
 }
 
-func (rt *reflectTest) TestGetColumnMap_withStructGoquTags() {
+func (rt *reflectTest) TestGetColumnMap_withStructDBTags() {
 
 	type TestStruct struct {
-		Str    string `goqu:"skipinsert,skipupdate"`
-		Int    int64  `goqu:"skipinsert"`
-		Bool   bool   `goqu:"skipupdate"`
-		Empty  bool   `goqu:"defaultifempty"`
+		Str    string `db:",skipinsert,skipupdate"`
+		Int    int64  `db:",skipinsert"`
+		Bool   bool   `db:",skipupdate"`
+		Empty  bool   `db:",defaultifempty"`
 		Valuer *sql.NullString
 	}
 	var ts TestStruct
@@ -989,7 +989,6 @@ func (rt *reflectTest) TestGetColumnMap_withStructGoquTags() {
 		"valuer": {ColumnName: "valuer", FieldIndex: []int{4}, ShouldInsert: true, ShouldUpdate: true, GoType: reflect.TypeOf(&sql.NullString{})},
 	}, cm)
 }
-
 func (rt *reflectTest) TestGetColumnMap_withStructWithTag() {
 
 	type TestStruct struct {
@@ -1029,12 +1028,12 @@ func (rt *reflectTest) TestGetColumnMap_withOmitemptyTag() {
 	}, cm)
 }
 
-func (rt *reflectTest) TestGetColumnMap_withStructWithTagAndGoquTag() {
+func (rt *reflectTest) TestGetColumnMap_withStructWithTagAndSkipTag() {
 
 	type TestStruct struct {
-		Str    string          `db:"s" goqu:"skipinsert,skipupdate"`
-		Int    int64           `db:"i" goqu:"skipinsert"`
-		Bool   bool            `db:"b" goqu:"skipupdate"`
+		Str    string          `db:"s,skipinsert,skipupdate"`
+		Int    int64           `db:"i,skipinsert"`
+		Bool   bool            `db:"b,skipupdate"`
 		Valuer *sql.NullString `db:"v"`
 	}
 	var ts TestStruct

--- a/issues_test.go
+++ b/issues_test.go
@@ -66,10 +66,10 @@ func (gis *githubIssuesSuite) TestIssue118_withEmbeddedStructWithoutExportedFiel
 	type Role struct {
 		*SimpleRole
 
-		ID        string    `json:"id" db:"id" goqu:"skipinsert"`
+		ID        string    `json:"id" db:"id,skipinsert"`
 		Key       string    `json:"key" db:"key"`
 		Name      string    `json:"name" db:"name"`
-		CreatedAt time.Time `json:"-" db:"created_at" goqu:"skipinsert"`
+		CreatedAt time.Time `json:"-" db:"created_at,skipinsert"`
 	}
 
 	rUser := &Role{
@@ -138,10 +138,10 @@ func (gis *githubIssuesSuite) TestIssue118_withNilEmbeddedStructWithExportedFiel
 	type Role struct {
 		*SimpleRole
 
-		ID        string    `json:"id" db:"id" goqu:"skipinsert"`
+		ID        string    `json:"id" db:"id,skipinsert"`
 		Key       string    `json:"key" db:"key"`
 		Name      string    `json:"name" db:"name"`
-		CreatedAt time.Time `json:"-" db:"created_at" goqu:"skipinsert"`
+		CreatedAt time.Time `json:"-" db:"created_at,skipinsert"`
 	}
 
 	rUser := &Role{

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -3,7 +3,7 @@ package sqlgen
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"github.com/lib/pq"
+	"github.com/doug-martin/goqu/v9/internal/types"
 	"reflect"
 	"strconv"
 	"time"
@@ -326,19 +326,7 @@ func (esg *expressionSQLGenerator) literalBytes(b sb.SQLBuilder, bs []byte) {
 		return
 	}
 	b.WriteRunes(esg.dialectOptions.StringQuote)
-	// TODO:
-	// Does i have any purpose?
-	i := 0
-	for len(bs) > 0 {
-		char, l := utf8.DecodeRune(bs)
-		if e, ok := esg.dialectOptions.EscapedRunes[char]; ok {
-			b.Write(e)
-		} else {
-			b.WriteRunes(char)
-		}
-		i++
-		bs = bs[l:]
-	}
+	esg.formatRune(b, bs)
 	b.WriteRunes(esg.dialectOptions.StringQuote)
 }
 func (esg *expressionSQLGenerator) formatRune(b sb.SQLBuilder, bs []byte) {
@@ -376,31 +364,32 @@ func (esg *expressionSQLGenerator) embedValueSQL(b sb.SQLBuilder, embed util.Emb
 
 	// if not prepared, embedded values must be reduce to bytes.
 	// check to see if value can be type asserted to implement scanner/valuer interface
+	// pq array library is imported to ease of use and simplicity. These types could be
 	switch v := embed.Value().(type) {
 	case []bool:
-		esg.Generate(b, (*pq.BoolArray)(&v))
+		esg.Generate(b, (*types.BoolArray)(&v))
 		return
 	case []float64:
-		esg.Generate(b, (*pq.Float64Array)(&v))
+		esg.Generate(b, (*types.Float64Array)(&v))
 		return
 	case []int64:
-		esg.Generate(b, (*pq.Int64Array)(&v))
+		esg.Generate(b, (*types.Int64Array)(&v))
 		return
 	case []string:
-		esg.Generate(b, (*pq.StringArray)(&v))
+		esg.Generate(b, (*types.StringArray)(&v))
 		return
 
 	case *[]bool:
-		esg.Generate(b, (*pq.BoolArray)(v))
+		esg.Generate(b, (*types.BoolArray)(v))
 		return
 	case *[]float64:
-		esg.Generate(b, (*pq.Float64Array)(v))
+		esg.Generate(b, (*types.Float64Array)(v))
 		return
 	case *[]int64:
-		esg.Generate(b, (*pq.Int64Array)(v))
+		esg.Generate(b, (*types.Int64Array)(v))
 		return
 	case *[]string:
-		esg.Generate(b, (*pq.StringArray)(v))
+		esg.Generate(b, (*types.StringArray)(v))
 		return
 	}
 

--- a/update_dataset_example_test.go
+++ b/update_dataset_example_test.go
@@ -466,6 +466,79 @@ func ExampleUpdateDataset_Set_struct() {
 	// UPDATE "items" SET "address"='111 Test Addr',"name"='Test' []
 }
 
+func ExampleUpdateDataset_Set_withEmbeddedValues() {
+	type Address struct {
+		Line1 string
+		City  string
+	}
+	type User struct {
+		FirstName        string
+		LastName         string
+		BestFriends      []string               `db:"best_friends,embed"`
+		FavoriteIceCream []string               `db:"favorite_ice_cream,embed,omitempty"`
+		CRUD             []bool                 `db:"crud,embed"`
+		Address          *Address               `db:",embed,omitempty"`
+		Map              map[string]interface{} `db:"map,embed"`
+	}
+	ds := goqu.Update("user").Set(
+		User{
+			FirstName:   "Greg",
+			LastName:    "Farley",
+			BestFriends: []string{"jane smith", "john doe"},
+			CRUD:        []bool{true, true, false, true},
+			Address: &Address{
+				Line1: "555 random road",
+				City:  "strange city",
+			},
+			Map: map[string]interface{}{
+				"key":    "value",
+				"number": 5,
+			},
+		},
+	)
+	insertSQL, args, _ := ds.ToSQL()
+	fmt.Println(insertSQL, args)
+
+	// Output:
+	// UPDATE "user" SET "address"='{"Line1":"555 random road","City":"strange city"}',"best_friends"='{"jane smith","john doe"}',"crud"='{t,t,f,t}',"firstname"='Greg',"lastname"='Farley',"map"='{"key":"value","number":5}' []
+}
+func ExampleUpdateDataset_Set_withEmbeddedValuesPrepared() {
+	type Address struct {
+		Line1 string
+		City  string
+	}
+	type User struct {
+		FirstName        string
+		LastName         string
+		BestFriends      []string               `db:"best_friends,embed"`
+		FavoriteIceCream []string               `db:"favorite_ice_cream,embed,omitempty"`
+		CRUD             []bool                 `db:"crud,embed"`
+		Address          Address                `db:",embed,omitempty"`
+		Map              map[string]interface{} `db:"map,embed"`
+	}
+	ds := goqu.Update("user").Set(
+		User{
+			FirstName:   "Greg",
+			LastName:    "Farley",
+			BestFriends: []string{"jane smith", "john doe"},
+			CRUD:        []bool{true, true, false, true},
+			Address: Address{
+				Line1: "555 random road",
+				City:  "strange city",
+			},
+			Map: map[string]interface{}{
+				"key":    "value",
+				"number": 5,
+			},
+		},
+	)
+	insertSQL, args, _ := ds.Prepared(true).ToSQL()
+	fmt.Println(insertSQL, args)
+
+	// Output:
+	// UPDATE "user" SET "address"=?,"best_friends"=?,"crud"=?,"firstname"=?,"lastname"=?,"map"=? [{555 random road strange city} [jane smith john doe] [true true false true] Greg Farley map[key:value number:5]]
+}
+
 func ExampleUpdateDataset_Set_goquRecord() {
 	sql, args, _ := goqu.Update("items").Set(
 		goqu.Record{"name": "Test", "address": "111 Test Addr"},


### PR DESCRIPTION
This PR brings support for Embedded values (issue #175  and issue #174). This is still a work in progress, but most (not all) old and new tests pass. This is to be taken as a proof of concept to discuss if it's even worth implementing. 

Breaking change (no longer breaking*): 
I removed the goqu tag in the reflect package. After doing some refactoring and cleanup to the tags pkg it's now simpler to just have a series of options like, `db:"column_name,option1,option2,option3,etc.` rather than `db:"" goqu:""`. 

* With commit [ff753e3](https://github.com/doug-martin/goqu/pull/180/commits/ff753e334265bb195a376b9242273f566600fe54) this isn't the case anymore. Can include both chained db and goqu tags... But I'd personally suggest staying with `db:""` since it does the same as `goqu:""` tag

Couple additions
New struct tags:
- `db:",omitempty"` if you value is nil and has a tag of `omitempty`, neither the column or the value will be added to the statement / argument list. **One big gotcha here.** If you are inserting/updating a slice of structs and one of the field values is nil with `omitempty` while the other struct has a value, goqu/sql will fail since one map/record has a different column count. This probably could be worked around, but haven't looked into it much yet.
- `db:",follow"` Identical to [anonymous embedded types](https://godoc.org/github.com/doug-martin/goqu#example-InsertDataset-Rows-WithEmbeddedStruct), but now allows struct fields to be named without being dot notated like, "struct_one"."struct_two"
- `db:",embed"` this will embed the value into the sql statement and argument list. Useful for json columns or db libraries that support auto serialization. For prepared statements the value is added to the argument list and is complete. For interpolated statements, goqu will attempt to reduce the value to []bytes or json marshal a struct/map for you. 

Example of embedded value
```go
func ExampleInsertDataset_Rows_withEmbeddedValues() {
	type Address struct {
		Line1 string
		City  string
	}
	type User struct {
		FirstName        string
		LastName         string
		BestFriends      []string               `db:"best_friends,embed"`
		FavoriteIceCream []string               `db:"favorite_ice_cream,embed,omitempty"` // note the chaining of options and omitting of this value since it's nil 
		CRUD             []bool                 `db:"crud,embed"`
		Address          *Address               `db:",embed,omitempty"` // name is always first tag item. To have options but use struct field name (in this case Address), start the tag with a comma
		Map              map[string]interface{} `db:"map,embed"`
	}
	ds := goqu.Insert("user").Rows(
		User{
			FirstName:   "Greg",
			LastName:    "Farley",
			BestFriends: []string{"jane smith", "john doe"},
			CRUD:        []bool{true, true, false, true},
			Address: &Address{
				Line1: "555 random road",
				City:  "strange city",
			},
			Map: map[string]interface{}{
				"key":    "value",
				"number": 5,
			},
		},
	)

        // interpolated
	insertSQL, args, _ := ds.ToSQL()

	// Output:
	// INSERT INTO "user" ("address", "best_friends", "crud", "firstname", "lastname", "map") VALUES ('{"Line1":"555 random road","City":"strange city"}', '{"jane smith","john doe"}', '{t,t,f,t}', 'Greg', 'Farley', '{"key":"value","number":5}') []

        // prepared
        insertSQL, args, _ = ds.Prepared(true).ToSQL()

	// Output:
	// INSERT INTO "user" ("address", "best_friends", "crud", "firstname", "lastname", "map") VALUES (?, ?, ?, ?, ?, ?) [{555 random road strange city} [jane smith john doe] [true true false true] Greg Farley map[key:value number:5]]
}
```