### PR TITLE
Fix ReturnsColumns() nil pointer panic

### DIFF
--- a/delete_dataset.go
+++ b/delete_dataset.go
@@ -217,10 +217,7 @@ func (dd *DeleteDataset) GetAs() exp.IdentifierExpression {
 }
 
 func (dd *DeleteDataset) ReturnsColumns() bool {
-	if cols := dd.clauses.Returning(); cols != nil {
-		return !cols.IsEmpty()
-	}
-	return false
+	return dd.clauses.HasReturning()
 }
 
 // Creates an QueryExecutor to execute the query.

--- a/delete_dataset.go
+++ b/delete_dataset.go
@@ -217,7 +217,10 @@ func (dd *DeleteDataset) GetAs() exp.IdentifierExpression {
 }
 
 func (dd *DeleteDataset) ReturnsColumns() bool {
-	return !dd.clauses.Returning().IsEmpty()
+	if cols := dd.clauses.Returning(); cols != nil {
+		return !cols.IsEmpty()
+	}
+	return false
 }
 
 // Creates an QueryExecutor to execute the query.

--- a/delete_dataset_test.go
+++ b/delete_dataset_test.go
@@ -379,6 +379,12 @@ func (dds *deleteDatasetSuite) TestReturning() {
 	)
 }
 
+func (dds *deleteDatasetSuite) TestReturnsColumns() {
+	ds := Delete("test")
+	dds.False(ds.ReturnsColumns())
+	dds.True(ds.Returning("foo", "bar").ReturnsColumns())
+}
+
 func (dds *deleteDatasetSuite) TestToSQL() {
 	md := new(mocks.SQLDialect)
 	ds := Delete("test").SetDialect(md)

--- a/exp/delete_clauses.go
+++ b/exp/delete_clauses.go
@@ -166,7 +166,7 @@ func (dc *deleteClauses) Returning() ColumnListExpression {
 }
 
 func (dc *deleteClauses) HasReturning() bool {
-	return dc.returning != nil
+	return dc.returning != nil && !dc.returning.IsEmpty()
 }
 
 func (dc *deleteClauses) SetReturning(cl ColumnListExpression) DeleteClauses {

--- a/exp/insert_clauses.go
+++ b/exp/insert_clauses.go
@@ -112,7 +112,7 @@ func (ic *insertClauses) Returning() ColumnListExpression {
 }
 
 func (ic *insertClauses) HasReturning() bool {
-	return ic.returning != nil
+	return ic.returning != nil && !ic.returning.IsEmpty()
 }
 
 func (ic *insertClauses) SetReturning(cl ColumnListExpression) InsertClauses {

--- a/exp/update_clauses.go
+++ b/exp/update_clauses.go
@@ -205,7 +205,7 @@ func (uc *updateClauses) Returning() ColumnListExpression {
 }
 
 func (uc *updateClauses) HasReturning() bool {
-	return uc.returning != nil
+	return uc.returning != nil && !uc.returning.IsEmpty()
 }
 
 func (uc *updateClauses) SetReturning(cl ColumnListExpression) UpdateClauses {

--- a/insert_dataset.go
+++ b/insert_dataset.go
@@ -229,7 +229,10 @@ func (id *InsertDataset) GetAs() exp.IdentifierExpression {
 }
 
 func (id *InsertDataset) ReturnsColumns() bool {
-	return !id.clauses.Returning().IsEmpty()
+	if cols := id.clauses.Returning(); cols != nil {
+		return !cols.IsEmpty()
+	}
+	return false
 }
 
 // Generates the INSERT sql, and returns an QueryExecutor struct with the sql set to the INSERT statement

--- a/insert_dataset.go
+++ b/insert_dataset.go
@@ -229,10 +229,7 @@ func (id *InsertDataset) GetAs() exp.IdentifierExpression {
 }
 
 func (id *InsertDataset) ReturnsColumns() bool {
-	if cols := id.clauses.Returning(); cols != nil {
-		return !cols.IsEmpty()
-	}
-	return false
+	return id.clauses.HasReturning()
 }
 
 // Generates the INSERT sql, and returns an QueryExecutor struct with the sql set to the INSERT statement

--- a/insert_dataset_test.go
+++ b/insert_dataset_test.go
@@ -383,6 +383,12 @@ func (ids *insertDatasetSuite) TestReturning() {
 	)
 }
 
+func (ids *insertDatasetSuite) TestReturnsColumns() {
+	ds := Insert("test")
+	ids.False(ds.ReturnsColumns())
+	ids.True(ds.Returning("foo", "bar").ReturnsColumns())
+}
+
 func (ids *insertDatasetSuite) TestExecutor() {
 	mDb, _, err := sqlmock.New()
 	ids.NoError(err)

--- a/update_dataset.go
+++ b/update_dataset.go
@@ -222,7 +222,10 @@ func (ud *UpdateDataset) GetAs() exp.IdentifierExpression {
 }
 
 func (ud *UpdateDataset) ReturnsColumns() bool {
-	return !ud.clauses.Returning().IsEmpty()
+	if cols := ud.clauses.Returning(); cols != nil {
+		return !cols.IsEmpty()
+	}
+	return false
 }
 
 // Generates the UPDATE sql, and returns an exec.QueryExecutor with the sql set to the UPDATE statement

--- a/update_dataset.go
+++ b/update_dataset.go
@@ -222,10 +222,7 @@ func (ud *UpdateDataset) GetAs() exp.IdentifierExpression {
 }
 
 func (ud *UpdateDataset) ReturnsColumns() bool {
-	if cols := ud.clauses.Returning(); cols != nil {
-		return !cols.IsEmpty()
-	}
-	return false
+	return ud.clauses.HasReturning()
 }
 
 // Generates the UPDATE sql, and returns an exec.QueryExecutor with the sql set to the UPDATE statement

--- a/update_dataset_test.go
+++ b/update_dataset_test.go
@@ -378,6 +378,12 @@ func (uds *updateDatasetSuite) TestReturning() {
 	)
 }
 
+func (uds *updateDatasetSuite) TestReturnsColumns() {
+	ds := Update("test")
+	uds.False(ds.ReturnsColumns())
+	uds.True(ds.Returning("foo", "bar").ReturnsColumns())
+}
+
 func (uds *updateDatasetSuite) TestToSQL() {
 	md := new(mocks.SQLDialect)
 	ds := Update("test").SetDialect(md)


### PR DESCRIPTION
`InsertDataset.ReturnsColumns()` `UpdateDataset.ReturnsColumns()` `DeleteDataset.ReturnsColumns()` panic when `clauses.Returning()` return nil