### PR TITLE
Fix for issue 178

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 * [FIXED] Fix ReturnsColumns() nil pointer panic [#181](https://github.com/doug-martin/goqu/issues/181) - [@yeaha](https://github.com/yeaha)
 * [FIXED] SelectDataset From with Error [#183](https://github.com/doug-martin/goqu/issues/183)
 * [FIXED] Unable to execute union with order by expression [#185](https://github.com/doug-martin/goqu/issues/185)
+* [FIXED] SQlite dialect escapes single quotes wrong, leads to SQL syntax error [#178](https://github.com/doug-martin/goqu/issues/178)
 
 # v9.5.0
 

--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -50,13 +50,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	}
 	opts.UseLiteralIsBools = false
 	opts.EscapedRunes = map[rune][]byte{
-		'\'': []byte("\\'"),
-		'"':  []byte("\\\""),
-		'\\': []byte("\\\\"),
-		'\n': []byte("\\n"),
-		'\r': []byte("\\r"),
-		0:    []byte("\\x00"),
-		0x1a: []byte("\\x1a"),
+		'\'': []byte("''"),
 	}
 	opts.InsertIgnoreClause = []byte("INSERT OR IGNORE")
 	opts.ConflictFragment = []byte("")

--- a/dialect/sqlite3/sqlite3_dialect_test.go
+++ b/dialect/sqlite3/sqlite3_dialect_test.go
@@ -63,31 +63,31 @@ func (sds *sqlite3DialectSuite) TestLiteralString() {
 
 	sql, _, err = ds.Where(goqu.C("a").Eq("test'test")).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\'test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test''test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq(`test"test`)).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\\"test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\"test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq(`test\test`)).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\\\test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq("test\ntest")).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\ntest')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\ntest')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq("test\rtest")).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\rtest')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\rtest')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq("test\x00test")).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\x00test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\x00test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq("test\x1atest")).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\x1atest')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\x1atest')", sql)
 }
 
 func (sds *sqlite3DialectSuite) TestLiteralBytes() {
@@ -98,31 +98,31 @@ func (sds *sqlite3DialectSuite) TestLiteralBytes() {
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte("test'test"))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\'test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test''test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte(`test"test`))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\\"test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\"test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte(`test\test`))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\\\test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte("test\ntest"))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\ntest')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\ntest')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte("test\rtest"))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\rtest')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\rtest')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte("test\x00test"))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\x00test')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\x00test')", sql)
 
 	sql, _, err = ds.Where(goqu.C("a").Eq([]byte("test\x1atest"))).ToSQL()
 	sds.NoError(err)
-	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\\x1atest')", sql)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 'test\x1atest')", sql)
 }
 
 func (sds *sqlite3DialectSuite) TestBooleanOperations() {


### PR DESCRIPTION
* [FIXED] SQlite dialect escapes single quotes wrong, leads to SQL syntax error [#178](https://github.com/doug-martin/goqu/issues/178)