### PR TITLE
Fixes to sqlite dialect: do not add FOR UPDATE in SELECT, fix support for INSERT ON CONFLICT

### DIFF
--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -57,6 +57,8 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.ConflictFragment = []byte("")
 	opts.ConflictDoUpdateFragment = []byte("")
 	opts.ConflictDoNothingFragment = []byte("")
+	opts.ForUpdateFragment = []byte("")
+	opts.NowaitFragment = []byte("")
 	return opts
 }
 

--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -1,9 +1,10 @@
 package sqlite3
 
 import (
+	"time"
+
 	"github.com/doug-martin/goqu/v9"
 	"github.com/doug-martin/goqu/v9/exp"
-	"time"
 )
 
 func DialectOptions() *goqu.SQLDialectOptions {

--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -3,6 +3,7 @@ package sqlite3
 import (
 	"github.com/doug-martin/goqu/v9"
 	"github.com/doug-martin/goqu/v9/exp"
+	"time"
 )
 
 func DialectOptions() *goqu.SQLDialectOptions {
@@ -15,7 +16,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.SupportsLimitOnDelete = true
 	opts.SupportsConflictUpdateWhere = false
 	opts.SupportsInsertIgnoreSyntax = true
-	opts.SupportsConflictTarget = false
+	opts.SupportsConflictTarget = true
 	opts.SupportsMultipleUpdateTables = false
 	opts.WrapCompoundsInParens = false
 	opts.SupportsDistinctOn = false
@@ -28,7 +29,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.DefaultValuesFragment = []byte("")
 	opts.True = []byte("1")
 	opts.False = []byte("0")
-	opts.TimeFormat = "2006-01-02 15:04:05"
+	opts.TimeFormat = time.RFC3339Nano
 	opts.BooleanOperatorLookup = map[exp.BooleanOperation][]byte{
 		exp.EqOp:             []byte("="),
 		exp.NeqOp:            []byte("!="),
@@ -53,10 +54,10 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.EscapedRunes = map[rune][]byte{
 		'\'': []byte("''"),
 	}
-	opts.InsertIgnoreClause = []byte("INSERT OR IGNORE")
-	opts.ConflictFragment = []byte("")
-	opts.ConflictDoUpdateFragment = []byte("")
-	opts.ConflictDoNothingFragment = []byte("")
+	opts.InsertIgnoreClause = []byte("INSERT OR IGNORE INTO ")
+	opts.ConflictFragment = []byte(" ON CONFLICT ")
+	opts.ConflictDoUpdateFragment = []byte(" DO UPDATE SET ")
+	opts.ConflictDoNothingFragment = []byte(" DO NOTHING ")
 	opts.ForUpdateFragment = []byte("")
 	opts.NowaitFragment = []byte("")
 	return opts

--- a/dialect/sqlite3/sqlite3_dialect_test.go
+++ b/dialect/sqlite3/sqlite3_dialect_test.go
@@ -194,6 +194,17 @@ func (sds *sqlite3DialectSuite) TestBooleanOperations() {
 	sds.Equal("SELECT * FROM `test` WHERE (`a` NOT REGEXP '(a|b)')", sql)
 }
 
+func (sds *sqlite3DialectSuite) TestForUpdate() {
+	ds := sds.GetDs("test")
+	sql, _, err := ds.Where(goqu.C("a").Eq(1)).ForUpdate(goqu.Wait).ToSQL()
+	sds.NoError(err)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 1)", sql)
+
+	sql, _, err = ds.Where(goqu.C("a").Eq(1)).ForUpdate(goqu.NoWait).ToSQL()
+	sds.NoError(err)
+	sds.Equal("SELECT * FROM `test` WHERE (`a` = 1)", sql)
+}
+
 func TestDatasetAdapterSuite(t *testing.T) {
 	suite.Run(t, new(sqlite3DialectSuite))
 }

--- a/dialect/sqlite3/sqlite3_test.go
+++ b/dialect/sqlite3/sqlite3_test.go
@@ -25,16 +25,16 @@ const (
 		"`bytes` BLOB NOT NULL" +
 		");"
 	insertDefaultRecords = "INSERT INTO `entry` (`int`, `float`, `string`, `time`, `bool`, `bytes`) VALUES" +
-		"(0, 0.000000, '0.000000', '2015-02-22 18:19:55', 1,  '0.000000')," +
-		"(1, 0.100000, '0.100000', '2015-02-22 19:19:55', 0, '0.100000')," +
-		"(2, 0.200000, '0.200000', '2015-02-22 20:19:55', 1,  '0.200000')," +
-		"(3, 0.300000, '0.300000', '2015-02-22 21:19:55', 0, '0.300000')," +
-		"(4, 0.400000, '0.400000', '2015-02-22 22:19:55', 1,  '0.400000')," +
-		"(5, 0.500000, '0.500000', '2015-02-22 23:19:55', 0, '0.500000')," +
-		"(6, 0.600000, '0.600000', '2015-02-23 00:19:55', 1,  '0.600000')," +
-		"(7, 0.700000, '0.700000', '2015-02-23 01:19:55', 0, '0.700000')," +
-		"(8, 0.800000, '0.800000', '2015-02-23 02:19:55', 1,  '0.800000')," +
-		"(9, 0.900000, '0.900000', '2015-02-23 03:19:55', 0, '0.900000');"
+		"(0, 0.000000, '0.000000', '2015-02-22T18:19:55.000000000-00:00', 1,  '0.000000')," +
+		"(1, 0.100000, '0.100000', '2015-02-22T19:19:55.000000000-00:00', 0, '0.100000')," +
+		"(2, 0.200000, '0.200000', '2015-02-22T20:19:55.000000000-00:00', 1,  '0.200000')," +
+		"(3, 0.300000, '0.300000', '2015-02-22T21:19:55.000000000-00:00', 0, '0.300000')," +
+		"(4, 0.400000, '0.400000', '2015-02-22T22:19:55.000000000-00:00', 1,  '0.400000')," +
+		"(5, 0.500000, '0.500000', '2015-02-22T23:19:55.000000000-00:00', 0, '0.500000')," +
+		"(6, 0.600000, '0.600000', '2015-02-23T00:19:55.000000000-00:00', 1,  '0.600000')," +
+		"(7, 0.700000, '0.700000', '2015-02-23T01:19:55.000000000-00:00', 0, '0.700000')," +
+		"(8, 0.800000, '0.800000', '2015-02-23T02:19:55.000000000-00:00', 1,  '0.800000')," +
+		"(9, 0.900000, '0.900000', '2015-02-23T03:19:55.000000000-00:00', 0, '0.900000');"
 )
 
 var dbURI = ":memory:"
@@ -118,7 +118,7 @@ func (st *sqlite3Suite) TestQuery() {
 	st.NoError(ds.Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	st.Len(entries, 10)
 	floatVal := float64(0)
-	baseDate, err := time.Parse(DialectOptions().TimeFormat, "2015-02-22 18:19:55")
+	baseDate, err := time.Parse(DialectOptions().TimeFormat, "2015-02-22T18:19:55.000000000-00:00")
 	st.NoError(err)
 	for i, entry := range entries {
 		f := fmt.Sprintf("%f", floatVal)
@@ -128,7 +128,7 @@ func (st *sqlite3Suite) TestQuery() {
 		st.Equal(f, entry.String)
 		st.Equal([]byte(f), entry.Bytes)
 		st.Equal(i%2 == 0, entry.Bool)
-		st.Equal(baseDate.Add(time.Duration(i)*time.Hour), entry.Time)
+		st.Equal(baseDate.Add(time.Duration(i)*time.Hour).Unix(), entry.Time.Unix())
 		floatVal += float64(0.1)
 	}
 	entries = entries[0:0]
@@ -215,7 +215,7 @@ func (st *sqlite3Suite) TestQuery_Prepared() {
 	st.NoError(ds.Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	st.Len(entries, 10)
 	floatVal := float64(0)
-	baseDate, err := time.Parse(DialectOptions().TimeFormat, "2015-02-22 18:19:55")
+	baseDate, err := time.Parse(DialectOptions().TimeFormat, "2015-02-22T18:19:55.000000000-00:00")
 	st.NoError(err)
 	for i, entry := range entries {
 		f := fmt.Sprintf("%f", floatVal)
@@ -225,7 +225,7 @@ func (st *sqlite3Suite) TestQuery_Prepared() {
 		st.Equal(f, entry.String)
 		st.Equal([]byte(f), entry.Bytes)
 		st.Equal(i%2 == 0, entry.Bool)
-		st.Equal(baseDate.Add(time.Duration(i)*time.Hour), entry.Time)
+		st.Equal(baseDate.Add(time.Duration(i)*time.Hour).Unix(), entry.Time.Unix())
 		floatVal += float64(0.1)
 	}
 	entries = entries[0:0]
@@ -311,7 +311,7 @@ func (st *sqlite3Suite) TestQuery_ValueExpressions() {
 		entry
 		BoolValue bool `db:"bool_value"`
 	}
-	expectedDate, err := time.Parse("2006-01-02 15:04:05", "2015-02-22 19:19:55")
+	expectedDate, err := time.Parse("2006-01-02T15:04:05.000000000-00:00", "2015-02-22T19:19:55.000000000-00:00")
 	st.NoError(err)
 	ds := st.db.From("entry").Select(goqu.Star(), goqu.V(true).As("bool_value")).Where(goqu.Ex{"int": 1})
 	var we wrappedEntry

--- a/dialect/sqlite3/sqlite3_test.go
+++ b/dialect/sqlite3/sqlite3_test.go
@@ -24,7 +24,7 @@ const (
 		"`bool` TINYINT NOT NULL ," +
 		"`bytes` BLOB NOT NULL" +
 		");"
-	insertDefaultReords = "INSERT INTO `entry` (`int`, `float`, `string`, `time`, `bool`, `bytes`) VALUES" +
+	insertDefaultRecords = "INSERT INTO `entry` (`int`, `float`, `string`, `time`, `bool`, `bytes`) VALUES" +
 		"(0, 0.000000, '0.000000', '2015-02-22 18:19:55', 1,  '0.000000')," +
 		"(1, 0.100000, '0.100000', '2015-02-22 19:19:55', 0, '0.100000')," +
 		"(2, 0.200000, '0.200000', '2015-02-22 20:19:55', 1,  '0.200000')," +
@@ -71,7 +71,7 @@ func (st *sqlite3Suite) SetupTest() {
 	if _, err := st.db.Exec(createTable); err != nil {
 		panic(err)
 	}
-	if _, err := st.db.Exec(insertDefaultReords); err != nil {
+	if _, err := st.db.Exec(insertDefaultRecords); err != nil {
 		panic(err)
 	}
 }

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -121,6 +121,7 @@ if err != nil{
 Output:
 ```
 SELECT * FROM "test" WHERE "id" = 10 []
+```
 
 ### Executing Queries 
 

--- a/sql_dialect.go
+++ b/sql_dialect.go
@@ -2,6 +2,7 @@ package goqu
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/doug-martin/goqu/v9/internal/sb"
@@ -37,6 +38,7 @@ type (
 var (
 	dialects              = make(map[string]SQLDialect)
 	DefaultDialectOptions = sqlgen.DefaultDialectOptions
+	dialectsMu            sync.RWMutex
 )
 
 func init() {
@@ -44,11 +46,15 @@ func init() {
 }
 
 func RegisterDialect(name string, do *SQLDialectOptions) {
+	dialectsMu.Lock()
+	defer dialectsMu.Unlock()
 	lowerName := strings.ToLower(name)
 	dialects[lowerName] = newDialect(lowerName, do)
 }
 
 func DeregisterDialect(name string) {
+	dialectsMu.Lock()
+	defer dialectsMu.Unlock()
 	delete(dialects, strings.ToLower(name))
 }
 


### PR DESCRIPTION
SQLite lacks support of SELECT FOR UPDATE: https://sqlite.org/lang_select.html

To enable cross-database queries building with that syntax and avoid additional conditions in application code, need to insert empty fragment for SQLite dialect