### PR TITLE
fix SQLServer dialect: support prepared statements with TOP, closes #225

### DIFF
--- a/dialect/sqlserver/sqlserver.go
+++ b/dialect/sqlserver/sqlserver.go
@@ -23,6 +23,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.SupportsWithCTERecursive = false
 	opts.SupportsDistinctOn = false
 	opts.SupportsWindowFunction = false
+	opts.SurroundLimitWithParentheses = true
 
 	opts.PlaceHolderFragment = []byte("@p")
 	opts.LimitFragment = []byte(" TOP ")

--- a/dialect/sqlserver/sqlserver_test.go
+++ b/dialect/sqlserver/sqlserver_test.go
@@ -358,6 +358,27 @@ func (mt *sqlserverTest) TestLimitOffset() {
 	mt.Equal(uint32(2), e.ID)
 }
 
+func (mt *sqlserverTest) TestLimitOffsetParameterized() {
+	ds := mt.db.From("entry").Prepared(true).Where(goqu.C("id").Gte(1)).Limit(1)
+	var e entry
+	found, err := ds.ScanStruct(&e)
+	mt.NoError(err)
+	mt.True(found)
+	mt.Equal(uint32(1), e.ID)
+
+	ds = mt.db.From("entry").Prepared(true).Where(goqu.C("id").Gte(1)).Order(goqu.C("id").Desc()).Limit(1)
+	found, err = ds.ScanStruct(&e)
+	mt.NoError(err)
+	mt.True(found)
+	mt.Equal(uint32(10), e.ID)
+
+	ds = mt.db.From("entry").Prepared(true).Where(goqu.C("id").Gte(1)).Order(goqu.C("id").Asc()).Offset(1).Limit(1)
+	found, err = ds.ScanStruct(&e)
+	mt.NoError(err)
+	mt.True(found)
+	mt.Equal(uint32(2), e.ID)
+}
+
 func (mt *sqlserverTest) TestInsert() {
 	ds := mt.db.From("entry")
 	now := time.Now()

--- a/sqlgen/common_sql_generator.go
+++ b/sqlgen/common_sql_generator.go
@@ -104,7 +104,13 @@ func (csg *commonSQLGenerator) OrderWithOffsetFetchSQL(
 func (csg *commonSQLGenerator) LimitSQL(b sb.SQLBuilder, limit interface{}) {
 	if limit != nil {
 		b.Write(csg.dialectOptions.LimitFragment)
+		if csg.dialectOptions.SurroundLimitWithParentheses {
+			b.WriteRunes(csg.dialectOptions.LeftParenRune)
+		}
 		csg.esg.Generate(b, limit)
+		if csg.dialectOptions.SurroundLimitWithParentheses {
+			b.WriteRunes(csg.dialectOptions.RightParenRune)
+		}
 	}
 }
 

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -45,6 +45,9 @@ type (
 		// Set to true if the dialect requires join tables in UPDATE to be in a FROM clause (DEFAULT=true).
 		UseFromClauseForMultipleUpdateTables bool
 
+		// Surround LIMIT parameter with parentheses, like in MSSQL: SELECT TOP (10) ...
+		SurroundLimitWithParentheses bool
+
 		// The UPDATE fragment to use when generating sql. (DEFAULT=[]byte("UPDATE"))
 		UpdateClause []byte
 		// The INSERT fragment to use when generating sql. (DEFAULT=[]byte("INSERT INTO"))


### PR DESCRIPTION
Added one more dialect property to be consistent with current approach (but placeholder with format for LIMIT fragment looked better IMHO)