### PR TITLE
add IsPrepared to SQLExpression interface

### DIFF
--- a/exp/exp.go
+++ b/exp/exp.go
@@ -151,6 +151,7 @@ type (
 	SQLExpression interface {
 		Expression
 		ToSQL() (string, []interface{}, error)
+		IsPrepared() bool
 	}
 
 	AppendableExpression interface {

--- a/exp/select_clauses_test.go
+++ b/exp/select_clauses_test.go
@@ -20,6 +20,10 @@ func (tse testSQLExpression) ToSQL() (sql string, args []interface{}, err error)
 	return "", nil, nil
 }
 
+func (tse testSQLExpression) IsPrepared() bool {
+	return false
+}
+
 type selectClausesSuite struct {
 	suite.Suite
 }


### PR DESCRIPTION
looks like it was not added accidentally in initial version :) anyway, it's convenient to have, I have at least one real use case where I need to know whether expression is prepared or not