### PR TITLE
v9.10.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ["1.12", "1.13", "1.14", "latest"]
+        go_version: ["1.14", "1.15", "latest"]
         db_versions:
           - mysql_version: 5
             postgres_version: 9.6

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# v9.10.0
+
+* [FIXED] SELECT inherits dialect from INSERT in INSERT FROM SELECT.  [#229](https://github.com/doug-martin/goqu/pull/229), [#223](https://github.com/doug-martin/goqu/issues/223) - [@vlanse](https://github.com/vlanse)
+* [FIXED] SQLServer dialect: support prepared statements with TOP.  [#230](https://github.com/doug-martin/goqu/pull/230), [#225](https://github.com/doug-martin/goqu/issues/225) - [@vlanse](https://github.com/vlanse)
+* [ADDED] IsPrepared to SQLExpression interface.  [#231](https://github.com/doug-martin/goqu/pull/231) - [@vlanse](https://github.com/vlanse)
+
 # v9.9.0
 
 * [FIXED] SQLite do not add FOR UPDATE in SELECT. [#218](https://github.com/doug-martin/goqu/pull/218) - [@vlanse](https://github.com/vlanse)


### PR DESCRIPTION
* [FIXED] SELECT inherits dialect from INSERT in INSERT FROM SELECT.  #229, #223 - @vlanse
* [FIXED] SQLServer dialect: support prepared statements with TOP.  #230, #225 - @vlanse
* [ADDED] IsPrepared to SQLExpression interface.  #231 - @vlanse