### PR TITLE
add dialect mariadb that supports RETURNING

### DIFF
--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -72,7 +72,14 @@ func DialectOptionsV8() *goqu.SQLDialectOptions {
 	return opts
 }
 
+func DialectOptionsMariaDB() *goqu.SQLDialectOptions {
+	opts := DialectOptions()
+	opts.SupportsReturn = true
+	return opts
+}
+
 func init() {
 	goqu.RegisterDialect("mysql", DialectOptions())
 	goqu.RegisterDialect("mysql8", DialectOptionsV8())
+	goqu.RegisterDialect("mariadb", DialectOptionsMariaDB())
 }


### PR DESCRIPTION
MariaDB supports RETURNING clause in the major stable release — 10.5

See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-105/#syntax