### PR TITLE
use valid 'IS' operator for sqlserver dialect, fixes #239

### DIFF
--- a/database.go
+++ b/database.go
@@ -626,7 +626,8 @@ func (td *TxDatabase) Wrap(fn func() error) (err error) {
 		if p := recover(); p != nil {
 			_ = td.Rollback()
 			panic(p)
-		} else if err != nil {
+		}
+		if err != nil {
 			if rollbackErr := td.Rollback(); rollbackErr != nil {
 				err = rollbackErr
 			}

--- a/database_test.go
+++ b/database_test.go
@@ -302,6 +302,15 @@ func (ds *databaseSuite) TestWithTx() {
 			wantErr: true,
 			errStr:  "goqu: transaction rollback error",
 		},
+		{
+			expectf: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectCommit().WillReturnError(errors.New("commit error"))
+			},
+			f:       func(_ *TxDatabase) error { return nil },
+			wantErr: true,
+			errStr:  "goqu: commit error",
+		},
 	}
 	for _, c := range cases {
 		c.expectf(mock)

--- a/dialect/sqlserver/sqlserver.go
+++ b/dialect/sqlserver/sqlserver.go
@@ -9,6 +9,7 @@ import (
 func DialectOptions() *goqu.SQLDialectOptions {
 	opts := goqu.DefaultDialectOptions()
 
+	opts.BooleanDataTypeSupported = false
 	opts.UseLiteralIsBools = false
 
 	opts.SupportsReturn = false
@@ -41,7 +42,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 		exp.LteOp:            []byte("<="),
 		exp.InOp:             []byte("IN"),
 		exp.NotInOp:          []byte("NOT IN"),
-		exp.IsOp:             []byte("="),
+		exp.IsOp:             []byte("IS"),
 		exp.IsNotOp:          []byte("IS NOT"),
 		exp.LikeOp:           []byte("LIKE"),
 		exp.NotLikeOp:        []byte("NOT LIKE"),

--- a/dialect/sqlserver/sqlserver_test.go
+++ b/dialect/sqlserver/sqlserver_test.go
@@ -121,9 +121,13 @@ func (mt *sqlserverTest) TestQuery() {
 	}
 	entries = entries[0:0]
 
-	mt.NoError(ds.Where(goqu.C("bool").IsTrue()).Order(goqu.C("id").Asc()).ScanStructs(&entries))
+	mt.Run("unsupported bool data type IS operation", func() {
+		_, _, err = ds.Where(goqu.C("bool").IsTrue()).Order(goqu.C("id").Asc()).ToSQL()
+		mt.Equal("goqu: boolean data type is not supported by dialect \"sqlserver\"", err.Error())
+	})
+
+	mt.NoError(ds.Where(goqu.C("bool").Eq(1)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Bool)
 	}
@@ -131,7 +135,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Gt(4)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int > 4)
 	}
@@ -139,7 +142,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Gte(5)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int >= 5)
 	}
@@ -147,7 +149,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Lt(5)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int < 5)
 	}
@@ -155,7 +156,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Lte(4)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int <= 4)
 	}
@@ -163,7 +163,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Between(goqu.Range(3, 6))).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 4)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int >= 3)
 		mt.True(entry.Int <= 6)
@@ -172,7 +171,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("string").Eq("0.100000")).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 1)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.Equal("0.100000", entry.String)
 	}
@@ -180,7 +178,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("string").Like("0.1%")).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 1)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.Equal("0.100000", entry.String)
 	}
@@ -188,7 +185,6 @@ func (mt *sqlserverTest) TestQuery() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("string").NotLike("0.1%")).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 9)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.NotEqual("0.100000", entry.String)
 	}
@@ -223,9 +219,14 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	}
 
 	entries = entries[0:0]
-	mt.NoError(ds.Where(goqu.C("bool").IsTrue()).Order(goqu.C("id").Asc()).ScanStructs(&entries))
+
+	mt.Run("unsupported bool data type IS operation", func() {
+		_, _, err = ds.Where(goqu.C("bool").IsTrue()).Order(goqu.C("id").Asc()).ToSQL()
+		mt.Equal("goqu: boolean data type is not supported by dialect \"sqlserver\"", err.Error())
+	})
+
+	mt.NoError(ds.Where(goqu.C("bool").Eq(1)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Bool)
 	}
@@ -233,7 +234,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Gt(4)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int > 4)
 	}
@@ -241,7 +241,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Gte(5)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int >= 5)
 	}
@@ -249,7 +248,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Lt(5)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int < 5)
 	}
@@ -257,7 +255,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Lte(4)).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 5)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int <= 4)
 	}
@@ -265,7 +262,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("int").Between(goqu.Range(3, 6))).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 4)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.True(entry.Int >= 3)
 		mt.True(entry.Int <= 6)
@@ -274,7 +270,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("string").Eq("0.100000")).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 1)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.Equal("0.100000", entry.String)
 	}
@@ -282,7 +277,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("string").Like("0.1%")).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 1)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.Equal("0.100000", entry.String)
 	}
@@ -290,7 +284,6 @@ func (mt *sqlserverTest) TestQuery_Prepared() {
 	entries = entries[0:0]
 	mt.NoError(ds.Where(goqu.C("string").NotLike("0.1%")).Order(goqu.C("id").Asc()).ScanStructs(&entries))
 	mt.Len(entries, 9)
-	mt.NoError(err)
 	for _, entry := range entries {
 		mt.NotEqual("0.100000", entry.String)
 	}

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -235,6 +235,8 @@ type (
 		// 		exp.CrossJoinType:        []byte(" CROSS JOIN "),
 		// 	})
 		JoinTypeLookup map[exp.JoinType][]byte
+		// Whether or not boolean data type is supported
+		BooleanDataTypeSupported bool
 		// Whether or not to use literal TRUE or FALSE for IS statements (e.g. IS TRUE or IS 0)
 		UseLiteralIsBools bool
 		// EscapedRunes is a map of a rune and the corresponding escape sequence in bytes. Used when escaping text
@@ -522,8 +524,10 @@ func DefaultDialectOptions() *SQLDialectOptions {
 			exp.CrossJoinType:        []byte(" CROSS JOIN "),
 		},
 
-		TimeFormat:        time.RFC3339Nano,
-		UseLiteralIsBools: true,
+		TimeFormat: time.RFC3339Nano,
+
+		BooleanDataTypeSupported: true,
+		UseLiteralIsBools:        true,
 
 		EscapedRunes: map[rune][]byte{
 			'\'': []byte("''"),


### PR DESCRIPTION
my proposal for fixing #239, new side effect is that explicit error will be returned when trying to construct query with IS / IS NOT operator other than for NULL value as RHS

Also, seems like support of boolean data type is a common "problem", AFAIK Oracle also does not have support for boolean, so explicit specification of it on dialect level looks good.


second commit is about handling panics in WithTx. It is not very uncommon situation when panic occurs inside for example REST handler for some reason. In this case current implementation will end up with "stuck" transaction which could prevent another transactions from normal operation.