### PR TITLE
add support for table hint in multi-table MySQL DELETE queries

### DIFF
--- a/delete_dataset_example_test.go
+++ b/delete_dataset_example_test.go
@@ -231,7 +231,7 @@ func ExampleDeleteDataset_ClearLimit() {
 	sql, _, _ := ds.ClearLimit().ToSQL()
 	fmt.Println(sql)
 	// Output:
-	// DELETE FROM `test`
+	// DELETE `test` FROM `test`
 }
 
 func ExampleDeleteDataset_Order() {

--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -20,6 +20,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.SupportsWithCTERecursive = false
 	opts.SupportsDistinctOn = false
 	opts.SupportsWindowFunction = false
+	opts.SupportsDeleteTableHint = true
 
 	opts.UseFromClauseForMultipleUpdateTables = false
 

--- a/sqlgen/delete_sql_generator.go
+++ b/sqlgen/delete_sql_generator.go
@@ -46,7 +46,9 @@ func (dsg *deleteSQLGenerator) Generate(b sb.SQLBuilder, clauses exp.DeleteClaus
 		case CommonTableSQLFragment:
 			dsg.esg.Generate(b, clauses.CommonTables())
 		case DeleteBeginSQLFragment:
-			dsg.DeleteBeginSQL(b)
+			dsg.DeleteBeginSQL(
+				b, exp.NewColumnListExpression(clauses.From()), !(clauses.HasLimit() || clauses.HasOrder()),
+			)
 		case FromSQLFragment:
 			dsg.FromSQL(b, exp.NewColumnListExpression(clauses.From()))
 		case WhereSQLFragment:
@@ -68,6 +70,9 @@ func (dsg *deleteSQLGenerator) Generate(b sb.SQLBuilder, clauses exp.DeleteClaus
 }
 
 // Adds the correct fragment to being an DELETE statement
-func (dsg *deleteSQLGenerator) DeleteBeginSQL(b sb.SQLBuilder) {
+func (dsg *deleteSQLGenerator) DeleteBeginSQL(b sb.SQLBuilder, from exp.ColumnListExpression, multiTable bool) {
 	b.Write(dsg.dialectOptions.DeleteClause)
+	if multiTable && dsg.dialectOptions.SupportsDeleteTableHint {
+		dsg.SourcesSQL(b, from)
+	}
 }

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -12,6 +12,8 @@ type (
 	SQLDialectOptions struct {
 		// Set to true if the dialect supports ORDER BY expressions in DELETE statements (DEFAULT=false)
 		SupportsOrderByOnDelete bool
+		// Set to true if the dialect supports table hint for DELETE statements (DELETE t FROM t ...), DEFAULT=false
+		SupportsDeleteTableHint bool
 		// Set to true if the dialect supports ORDER BY expressions in UPDATE statements (DEFAULT=false)
 		SupportsOrderByOnUpdate bool
 		// Set to true if the dialect supports LIMIT expressions in DELETE statements (DEFAULT=false)
@@ -393,6 +395,7 @@ func (sf SQLFragmentType) String() string {
 func DefaultDialectOptions() *SQLDialectOptions {
 	return &SQLDialectOptions{
 		SupportsOrderByOnDelete:     false,
+		SupportsDeleteTableHint:     false,
 		SupportsOrderByOnUpdate:     false,
 		SupportsLimitOnDelete:       false,
 		SupportsLimitOnUpdate:       false,


### PR DESCRIPTION
Example explains w/o and w. table hint, difference is obvious, and affects query efficiency dramatically

```sql
EXPLAIN DELETE FROM `t1` WHERE ((`t1`.`id` IN ((SELECT `id` FROM `t2` WHERE (`t2`.`p` LIKE '/a/b/%')))) AND (`t1`.`v1` IS NULL) AND (`t1`.`v2` = -1))

+----+--------------------+--------------+------------+-----------------+------------------+---------+---------+--------+--------+----------+-------------+
| id | select_type        | table        | partitions | type            | possible_keys    | key     | key_len | ref    | rows   | filtered | Extra       |
+----+--------------------+--------------+------------+-----------------+------------------+---------+---------+--------+--------+----------+-------------+
| 1  | DELETE             | t1           | <null>     | ALL             | <null>           | <null>  | <null>  | <null> | 107960 | 100.0    | Using where |
| 2  | DEPENDENT SUBQUERY | t2           | <null>     | unique_subquery | PRIMARY,path_idx | PRIMARY | 8       | func   | 1      |   5.0    | Using where |
+----+--------------------+--------------+------------+-----------------+------------------+---------+---------+--------+--------+----------+-------------+


EXPLAIN DELETE `t1` FROM `t1` WHERE ((`t1`.`id` IN ((SELECT `id` FROM `t2` WHERE (`t2`.`p` LIKE '/a/b/%')))) AND (`t1`.`v1` IS NULL) AND (`t1`.`v2` = -1))
+----+-------------+--------------+------------+-------+------------------+----------+---------+---------------+------+----------+--------------------------+
| id | select_type | table        | partitions | type  | possible_keys    | key      | key_len | ref           | rows | filtered | Extra                    |
+----+-------------+--------------+------------+-------+------------------+----------+---------+---------------+------+----------+--------------------------+
| 1  | SIMPLE      | t2           | <null>     | range | PRIMARY,p_idx    | p_idx    | 767     | <null>        | 1    | 100.0    | Using where; Using index |
| 1  | DELETE      | t1           | <null>     | ref   | PRIMARY          | PRIMARY  | 8       | t2.id         | 1    |   4.54   | Using where              |
+----+-------------+--------------+------------+-------+------------------+----------+---------+---------------+------+----------+--------------------------+
```