### PR TITLE
add ScanStructs, ScanVals to Scanner interface

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -67,7 +67,14 @@ func (ds *databaseSuite) TestScanStructs() {
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
-
+	mock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
+			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
+	mock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
+			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 	mock.ExpectQuery(`SELECT "test" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
@@ -121,6 +128,12 @@ func (ds *databaseSuite) TestScanStruct() {
 func (ds *databaseSuite) TestScanVals() {
 	mDB, mock, err := sqlmock.New()
 	ds.NoError(err)
+	mock.ExpectQuery(`SELECT "id" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
+	mock.ExpectQuery(`SELECT "id" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
 	mock.ExpectQuery(`SELECT "id" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
@@ -492,7 +505,14 @@ func (tds *txdatabaseSuite) TestScanStructs() {
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
-
+	mock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
+			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
+	mock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
+			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
 	mock.ExpectQuery(`SELECT "test" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
@@ -554,6 +574,12 @@ func (tds *txdatabaseSuite) TestScanVals() {
 	mDB, mock, err := sqlmock.New()
 	tds.NoError(err)
 	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT "id" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
+	mock.ExpectQuery(`SELECT "id" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
 	mock.ExpectQuery(`SELECT "id" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))

--- a/exec/query_executor.go
+++ b/exec/query_executor.go
@@ -79,18 +79,15 @@ func (q QueryExecutor) ScanStructs(i interface{}) error {
 //
 // i: A pointer to a slice of structs.
 func (q QueryExecutor) ScanStructsContext(ctx context.Context, i interface{}) error {
-	val := reflect.ValueOf(i)
-	if !util.IsPointer(val.Kind()) {
-		return errUnsupportedScanStructsType
+	if _, err := checkScanStructsTarget(i); err != nil {
+		return err
 	}
-	val = reflect.Indirect(val)
-	if !util.IsSlice(val.Kind()) {
-		return errUnsupportedScanStructsType
+	scanner, err := q.ScannerContext(ctx)
+	if err != nil {
+		return err
 	}
-
-	return q.scanIntoSlice(ctx, val, func(sc Scanner, r interface{}) error {
-		return sc.ScanStruct(r)
-	})
+	defer func() { _ = scanner.Close() }()
+	return scanner.ScanStructs(i)
 }
 
 // This will execute the SQL and fill out the struct with the fields returned.
@@ -136,7 +133,7 @@ func (q QueryExecutor) ScanStructContext(ctx context.Context, i interface{}) (bo
 		return false, err
 	}
 
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	if scanner.Next() {
 		err = scanner.ScanStruct(i)
@@ -169,18 +166,15 @@ func (q QueryExecutor) ScanVals(i interface{}) error {
 //
 // i: Takes a pointer to a slice of primitive values.
 func (q QueryExecutor) ScanValsContext(ctx context.Context, i interface{}) error {
-	val := reflect.ValueOf(i)
-	if !util.IsPointer(val.Kind()) {
-		return errUnsupportedScanValsType
+	if _, err := checkScanValsTarget(i); err != nil {
+		return err
 	}
-	val = reflect.Indirect(val)
-	if !util.IsSlice(val.Kind()) {
-		return errUnsupportedScanValsType
+	scanner, err := q.ScannerContext(ctx)
+	if err != nil {
+		return err
 	}
-
-	return q.scanIntoSlice(ctx, val, func(sc Scanner, r interface{}) error {
-		return sc.ScanVal(r)
-	})
+	defer func() { _ = scanner.Close() }()
+	return scanner.ScanVals(i)
 }
 
 // This will execute the SQL and set the value of the primitive. This method will return false if no record is found.
@@ -230,7 +224,7 @@ func (q QueryExecutor) ScanValContext(ctx context.Context, i interface{}) (bool,
 		return false, err
 	}
 
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	if scanner.Next() {
 		err = scanner.ScanVal(i)
@@ -256,27 +250,4 @@ func (q QueryExecutor) ScannerContext(ctx context.Context) (Scanner, error) {
 		return nil, err
 	}
 	return NewScanner(rows), nil
-}
-
-func (q QueryExecutor) scanIntoSlice(ctx context.Context, val reflect.Value, it func(sc Scanner, i interface{}) error) error {
-	elemType := util.GetSliceElementType(val)
-
-	scanner, err := q.ScannerContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	defer scanner.Close()
-
-	for scanner.Next() {
-		row := reflect.New(elemType)
-		err = it(scanner, row.Interface())
-		if err != nil {
-			return err
-		}
-
-		util.AppendSliceElement(val, row)
-	}
-
-	return scanner.Err()
 }

--- a/exec/query_executor.go
+++ b/exec/query_executor.go
@@ -79,9 +79,6 @@ func (q QueryExecutor) ScanStructs(i interface{}) error {
 //
 // i: A pointer to a slice of structs.
 func (q QueryExecutor) ScanStructsContext(ctx context.Context, i interface{}) error {
-	if _, err := checkScanStructsTarget(i); err != nil {
-		return err
-	}
 	scanner, err := q.ScannerContext(ctx)
 	if err != nil {
 		return err
@@ -166,9 +163,6 @@ func (q QueryExecutor) ScanVals(i interface{}) error {
 //
 // i: Takes a pointer to a slice of primitive values.
 func (q QueryExecutor) ScanValsContext(ctx context.Context, i interface{}) error {
-	if _, err := checkScanValsTarget(i); err != nil {
-		return err
-	}
 	scanner, err := q.ScannerContext(ctx)
 	if err != nil {
 		return err

--- a/exec/scanner_internal_test.go
+++ b/exec/scanner_internal_test.go
@@ -1,0 +1,69 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/suite"
+)
+
+type scannerSuite struct {
+	suite.Suite
+}
+
+func TestScanner(t *testing.T) {
+	suite.Run(t, &scannerSuite{})
+}
+
+func (s *scannerSuite) TestScanStructs() {
+	type StructWithTags struct {
+		Address string `db:"address"`
+		Name    string `db:"name"`
+	}
+	db, mock, err := sqlmock.New()
+	s.Require().NoError(err)
+
+	mock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
+			AddRow(testAddr1, testName1).
+			AddRow(testAddr2, testName2),
+		)
+	rows, err := db.Query(`SELECT * FROM "items"`)
+	s.Require().NoError(err)
+
+	sc := NewScanner(rows)
+
+	result := make([]StructWithTags, 0)
+	err = sc.ScanStructs(result)
+	s.Require().EqualError(err, errUnsupportedScanStructsType.Error())
+
+	err = sc.ScanStructs(&result)
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(
+		[]StructWithTags{{Address: testAddr1, Name: testName1}, {Address: testAddr2, Name: testName2}},
+		result,
+	)
+}
+
+func (s *scannerSuite) TestScanVals() {
+	db, mock, err := sqlmock.New()
+	s.Require().NoError(err)
+
+	mock.ExpectQuery(`SELECT "id" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+
+	rows, err := db.Query(`SELECT "id" FROM "items"`)
+	s.Require().NoError(err)
+
+	sc := NewScanner(rows)
+
+	result := make([]int, 0)
+	err = sc.ScanVals(result)
+	s.Require().EqualError(err, errUnsupportedScanValsType.Error())
+
+	err = sc.ScanVals(&result)
+	s.Require().NoError(err)
+	s.Require().ElementsMatch([]int{1, 2}, result)
+}

--- a/select_dataset_test.go
+++ b/select_dataset_test.go
@@ -1146,7 +1146,12 @@ func (sds *selectDatasetSuite) TestScanStructs() {
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
-
+	sqlMock.ExpectQuery(`SELECT "address", "name" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
+	sqlMock.ExpectQuery(`SELECT "address", "name" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
 	sqlMock.ExpectQuery(`SELECT "test" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
@@ -1186,6 +1191,13 @@ func (sds *selectDatasetSuite) TestScanStructs_WithPreparedStatements() {
 		WithArgs("111 Test Addr", "Bob", "Sally", "Billy").
 		WillReturnRows(sqlmock.NewRows([]string{"address", "name"}).
 			FromCSVString("111 Test Addr,Test1\n211 Test Addr,Test2"))
+
+	sqlMock.ExpectQuery(`SELECT "address", "name" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
+	sqlMock.ExpectQuery(`SELECT "address", "name" FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"test"}).FromCSVString("test1\ntest2"))
 
 	sqlMock.ExpectQuery(
 		`SELECT "test" FROM "items" WHERE \(\("address" = \?\) AND \("name" IN \(\?, \?, \?\)\)\)`,
@@ -1299,6 +1311,12 @@ func (sds *selectDatasetSuite) TestScanVals() {
 	sqlMock.ExpectQuery(`SELECT "id" FROM "items"`).
 		WithArgs().
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
+	sqlMock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
+	sqlMock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
 
 	db := goqu.New("mock", mDB)
 	var ids []uint32
@@ -1323,6 +1341,13 @@ func (sds *selectDatasetSuite) TestScanVals_WithPreparedStatment() {
 		WithArgs("111 Test Addr", "Bob", "Sally", "Billy").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
 
+	sqlMock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
+	sqlMock.ExpectQuery(`SELECT \* FROM "items"`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).FromCSVString("1\n2\n3\n4\n5"))
+
 	db := goqu.New("mock", mDB)
 	var ids []uint32
 	sds.NoError(db.From("items").
@@ -1334,6 +1359,7 @@ func (sds *selectDatasetSuite) TestScanVals_WithPreparedStatment() {
 
 	sds.EqualError(db.From("items").ScanVals([]uint32{}),
 		"goqu: type must be a pointer to a slice when scanning into vals")
+
 	sds.EqualError(db.From("items").ScanVals(dsTestActionItem{}),
 		"goqu: type must be a pointer to a slice when scanning into vals")
 }


### PR DESCRIPTION
`ScanStructs`, `ScanVals` methods are added to `Scanner` interface.
Rationale is to allow reuse goqu very convenient struct tags in case when goqu is used as query builder only (i.e. queries built with goqu but executed via `sql` module API). In my case such approach allows to make some advanced query processing, like metrics collection or scanning results on-by-one - that's why goqu executor is not always suitable.

Also, I wanted to reuse code from `internal/utils` as much as possible
