### PR TITLE
feat: allow untagged fields to be ignored

### DIFF
--- a/docs/selecting.md
+++ b/docs/selecting.md
@@ -890,6 +890,7 @@ Scans rows into a slice of structs
 type User struct{
   FirstName string `db:"first_name"`
   LastName  string `db:"last_name"`
+  Age       int    `db:"-"` // a field that shouldn't be selected
 }
 
 var users []User
@@ -909,7 +910,7 @@ fmt.Printf("\n%+v", users)
 
 `goqu` also supports scanning into multiple structs. In the example below we define a `Role` and `User` struct that could both be used individually to scan into. However, you can also create a new struct that adds both structs as fields that can be populated in a single query.
 
-**NOTE** When calling `ScanStructs` without a select already defined it will automatically only `SELECT` the columns found in the struct
+**NOTE** When calling `ScanStructs` without a select already defined it will automatically only `SELECT` the columns found in the struct, omitting any that are tagged with `db:"-"`
 
  ```go
 type Role struct {
@@ -990,6 +991,7 @@ Scans a row into a slice a struct, returns false if a row wasnt found
 type User struct{
   FirstName string `db:"first_name"`
   LastName  string `db:"last_name"`
+  Age       int    `db:"-"` // a field that shouldn't be selected
 }
 
 var user User
@@ -1008,7 +1010,7 @@ if !found {
 
 `goqu` also supports scanning into multiple structs. In the example below we define a `Role` and `User` struct that could both be used individually to scan into. However, you can also create a new struct that adds both structs as fields that can be populated in a single query.
 
-**NOTE** When calling `ScanStruct` without a select already defined it will automatically only `SELECT` the columns found in the struct
+**NOTE** When calling `ScanStruct` without a select already defined it will automatically only `SELECT` the columns found in the struct, omitting any that are tagged with `db:"-"`
 
  ```go
 type Role struct {
@@ -1101,6 +1103,23 @@ var user User
 found, err := db.From("user").ScanStruct(&user)
 // ...
 ```
+
+**NOTE** Using the `goqu.SetIgnoreUntaggedFields(true)` function, you can cause goqu to ignore any fields that aren't explicitly tagged.
+
+```go
+goqu.SetIgnoreUntaggedFields(true)
+
+type User struct{
+  FirstName string `db:"first_name"`
+  LastName string
+}
+
+var user User
+//SELECT "first_name" FROM "user" LIMIT 1;
+found, err := db.From("user").ScanStruct(&user)
+// ...
+```
+
 
 <a name="scan-vals"></a>
 **[`ScanVals`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanVals)**
@@ -1248,8 +1267,3 @@ if err := db.From("user").Pluck(&ids, "id"); err != nil{
 }
 fmt.Printf("\nIds := %+v", ids)
 ```
-
-
-
-
-

--- a/goqu.go
+++ b/goqu.go
@@ -66,6 +66,13 @@ func New(dialect string, db SQLDatabase) *Database {
 	return newDatabase(dialect, db)
 }
 
+// Set the behavior when encountering struct fields that do not have a db tag.
+// By default this is false; if set to true any field without a db tag will not
+// be targeted by Select or Scan operations.
+func SetIgnoreUntaggedFields(ignore bool) {
+	util.SetIgnoreUntaggedFields(ignore)
+}
+
 // Set the column rename function. This is used for struct fields that do not have a db tag to specify the column name
 // By default all struct fields that do not have a db tag will be converted lowercase
 func SetColumnRenameFunction(renameFunc func(string) string) {

--- a/internal/util/column_map.go
+++ b/internal/util/column_map.go
@@ -34,7 +34,7 @@ func newColumnMap(t reflect.Type, fieldIndex []int, prefixes []string) ColumnMap
 			dbTag := tag.New("db", f.Tag)
 			// if PkgPath is empty then it is an exported field
 			columnName := getColumnName(&f, dbTag)
-			if !dbTag.Equals("-") {
+			if !shouldIgnoreField(dbTag) {
 				if !implementsScanner(f.Type) {
 					subCm := getStructColumnMap(&f, fieldIndex, []string{columnName}, prefixes)
 					if len(subCm) != 0 {
@@ -110,4 +110,14 @@ func getColumnName(f *reflect.StructField, dbTag tag.Options) string {
 		return columnRenameFunction(f.Name)
 	}
 	return dbTag.Values()[0]
+}
+
+func shouldIgnoreField(dbTag tag.Options) bool {
+	if dbTag == "-" {
+		return true
+	} else if dbTag == "" && ignoreUntaggedFields {
+		return true
+	}
+
+	return false
 }

--- a/internal/util/column_map.go
+++ b/internal/util/column_map.go
@@ -113,9 +113,9 @@ func getColumnName(f *reflect.StructField, dbTag tag.Options) string {
 }
 
 func shouldIgnoreField(dbTag tag.Options) bool {
-	if dbTag == "-" {
+	if dbTag.Equals("-") {
 		return true
-	} else if dbTag == "" && ignoreUntaggedFields {
+	} else if dbTag.IsEmpty() && ignoreUntaggedFields {
 		return true
 	}
 

--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -91,7 +91,20 @@ var (
 var (
 	DefaultColumnRenameFunction = strings.ToLower
 	columnRenameFunction        = DefaultColumnRenameFunction
+	ignoreUntaggedFields        = false
 )
+
+func SetIgnoreUntaggedFields(ignore bool) {
+	// If the value here is changing, reset the struct map cache
+	if ignore != ignoreUntaggedFields {
+		ignoreUntaggedFields = ignore
+
+		structMapCacheLock.Lock()
+		defer structMapCacheLock.Unlock()
+
+		structMapCache = make(map[interface{}]ColumnMap)
+	}
+}
 
 func SetColumnRenameFunction(newFunction func(string) string) {
 	columnRenameFunction = newFunction


### PR DESCRIPTION
Per https://github.com/doug-martin/goqu/issues/284

This adds a `SetIgnoreUntaggedFields` function which sets the behavior when
encountering struct fields that do not have a db tag. By default this is
false; if set to true any field without a db tag will not be targeted by
Select or Scan operations.