### PR TITLE
fix old import URL in comments

### DIFF
--- a/database.go
+++ b/database.go
@@ -44,7 +44,7 @@ type (
 //          "database/sql"
 //          "fmt"
 //          "github.com/doug-martin/goqu/v9"
-//          _ "github.com/doug-martin/goqu/v9/adapters/postgres"
+//          _ "github.com/doug-martin/goqu/v9/dialect/postgres"
 //          _ "github.com/lib/pq"
 //      )
 //

--- a/goqu_example_test.go
+++ b/goqu_example_test.go
@@ -13,7 +13,7 @@ import (
 
 // Creating a mysql dataset. Be sure to import the mysql adapter.
 func ExampleDialect_datasetMysql() {
-	// import _ "github.com/doug-martin/goqu/v9/adapters/mysql"
+	// import _ "github.com/doug-martin/goqu/v9/dialect/mysql"
 
 	d := goqu.Dialect("mysql")
 	ds := d.From("test").Where(goqu.Ex{
@@ -34,7 +34,7 @@ func ExampleDialect_datasetMysql() {
 
 // Creating a mysql database. Be sure to import the mysql adapter.
 func ExampleDialect_dbMysql() {
-	// import _ "github.com/doug-martin/goqu/v9/adapters/mysql"
+	// import _ "github.com/doug-martin/goqu/v9/dialect/mysql"
 
 	type item struct {
 		ID      int64  `db:"id"`
@@ -84,7 +84,7 @@ func ExampleDialect_dbMysql() {
 
 // Creating a mysql dataset. Be sure to import the postgres adapter
 func ExampleDialect_datasetPostgres() {
-	// import _ "github.com/doug-martin/goqu/v9/adapters/postgres"
+	// import _ "github.com/doug-martin/goqu/v9/dialect/postgres"
 
 	d := goqu.Dialect("postgres")
 	ds := d.From("test").Where(goqu.Ex{
@@ -105,7 +105,7 @@ func ExampleDialect_datasetPostgres() {
 
 // Creating a postgres dataset. Be sure to import the postgres adapter
 func ExampleDialect_dbPostgres() {
-	// import _ "github.com/doug-martin/goqu/v9/adapters/postgres"
+	// import _ "github.com/doug-martin/goqu/v9/dialect/postgres"
 
 	type item struct {
 		ID      int64  `db:"id"`
@@ -155,7 +155,7 @@ func ExampleDialect_dbPostgres() {
 
 // Creating a mysql dataset. Be sure to import the sqlite3 adapter
 func ExampleDialect_datasetSqlite3() {
-	// import _ "github.com/doug-martin/goqu/v9/adapters/sqlite3"
+	// import _ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 
 	d := goqu.Dialect("sqlite3")
 	ds := d.From("test").Where(goqu.Ex{
@@ -176,7 +176,7 @@ func ExampleDialect_datasetSqlite3() {
 
 // Creating a sqlite3 database. Be sure to import the sqlite3 adapter
 func ExampleDialect_dbSqlite3() {
-	// import _ "github.com/doug-martin/goqu/v9/adapters/sqlite3"
+	// import _ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	type item struct {
 		ID      int64  `db:"id"`
 		Address string `db:"address"`

--- a/sql_dialect.go
+++ b/sql_dialect.go
@@ -23,7 +23,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	sqlDialect struct {
 		dialect        string
 		dialectOptions *SQLDialectOptions

--- a/sqlgen/delete_sql_generator.go
+++ b/sqlgen/delete_sql_generator.go
@@ -15,7 +15,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	deleteSQLGenerator struct {
 		CommonSQLGenerator
 	}

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -22,7 +22,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	expressionSQLGenerator struct {
 		dialect        string
 		dialectOptions *SQLDialectOptions

--- a/sqlgen/insert_sql_generator.go
+++ b/sqlgen/insert_sql_generator.go
@@ -17,7 +17,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	insertSQLGenerator struct {
 		CommonSQLGenerator
 	}

--- a/sqlgen/select_sql_generator.go
+++ b/sqlgen/select_sql_generator.go
@@ -15,7 +15,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	selectSQLGenerator struct {
 		CommonSQLGenerator
 	}

--- a/sqlgen/truncate_sql_generator.go
+++ b/sqlgen/truncate_sql_generator.go
@@ -17,7 +17,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	truncateSQLGenerator struct {
 		CommonSQLGenerator
 	}

--- a/sqlgen/update_sql_generator.go
+++ b/sqlgen/update_sql_generator.go
@@ -15,7 +15,7 @@ type (
 	}
 	// The default adapter. This class should be used when building a new adapter. When creating a new adapter you can
 	// either override methods, or more typically update default values.
-	// See (github.com/doug-martin/goqu/adapters/postgres)
+	// See (github.com/doug-martin/goqu/dialect/postgres)
 	updateSQLGenerator struct {
 		CommonSQLGenerator
 	}


### PR DESCRIPTION
now if I use `import` command at `github.com/doug-martin/goqu/v9/adapters/`

It doesn't work as below.

```
$ go get github.com/doug-martin/goqu/v9/adapters/postgres
go: downloading github.com/doug-martin/goqu v1.0.0
go: downloading github.com/doug-martin/goqu/v9 v9.13.0
go: downloading github.com/doug-martin/goqu v5.0.0+incompatible
go get: module github.com/doug-martin/goqu/v9@upgrade found (v9.13.0), but does not contain package github.com/doug-martin/goqu/v9/adapters/postgres
```

every implementation is fixed but some comments are still old links.