### PR TITLE
add godror oracle dialect support

### DIFF
--- a/dialect/godror/godror.go
+++ b/dialect/godror/godror.go
@@ -1,0 +1,16 @@
+package godror
+
+import (
+	"github.com/doug-martin/goqu/v9"
+)
+
+func DialectOptions() *goqu.SQLDialectOptions {
+	do := goqu.DefaultDialectOptions()
+	do.PlaceHolderFragment = []byte(":")
+	do.IncludePlaceholderNum = true
+	return do
+}
+
+func init() {
+	goqu.RegisterDialect("godror", DialectOptions())
+}


### PR DESCRIPTION
Simple dialect addition to support oracle via the godror package. 
Adding tests might be a bit of an issue as running oracle within a docker environment is quite costly.
Can reject if you think oracle is too esoteric for the project, I can rely on my own fork 