### PR TITLE
Fix truncate on SQLite (DELETE FROM)

### DIFF
--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -61,6 +61,8 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.EscapedRunes = map[rune][]byte{
 		'\'': []byte("''"),
 	}
+
+	opts.TruncateClause = []byte("DELETE FROM")
 	opts.InsertIgnoreClause = []byte("INSERT OR IGNORE INTO ")
 	opts.ConflictFragment = []byte(" ON CONFLICT ")
 	opts.ConflictDoUpdateFragment = []byte(" DO UPDATE SET ")


### PR DESCRIPTION
https://www.sqlite.org/lang_delete.html

SQLite does not have an explicit TRUNCATE TABLE and uses DELETE FROM
without WHERE clause.