### PR TITLE
improve dialects usage

### DIFF
--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -5,6 +5,9 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 )
 
+const DialectName = "mysql"
+const MySQL8DialectName = "mysql8"
+
 func DialectOptions() *goqu.SQLDialectOptions {
 	opts := goqu.DefaultDialectOptions()
 
@@ -82,6 +85,6 @@ func DialectOptionsV8() *goqu.SQLDialectOptions {
 }
 
 func init() {
-	goqu.RegisterDialect("mysql", DialectOptions())
-	goqu.RegisterDialect("mysql8", DialectOptionsV8())
+	goqu.RegisterDialect(DialectName, DialectOptions())
+	goqu.RegisterDialect(MySQL8DialectName, DialectOptionsV8())
 }

--- a/dialect/mysql/mysql_test.go
+++ b/dialect/mysql/mysql_test.go
@@ -465,7 +465,7 @@ func (mt *mysqlTest) TestWindowFunction() {
 		Window(goqu.W("w").OrderBy(goqu.I("int").Desc()))
 
 	var entries []entry
-	mt.NoError(ds.WithDialect("mysql8").ScanStructs(&entries))
+	mt.NoError(ds.WithDialect(mysql.MySQL8DialectName).ScanStructs(&entries))
 
 	mt.Equal([]entry{
 		{Int: 9, ID: 1},
@@ -480,7 +480,7 @@ func (mt *mysqlTest) TestWindowFunction() {
 		{Int: 0, ID: 10},
 	}, entries)
 
-	mt.Error(ds.WithDialect("mysql").ScanStructs(&entries), "goqu: adapter does not support window function clause")
+	mt.Error(ds.WithDialect(mysql.DialectName).ScanStructs(&entries), "goqu: adapter does not support window function clause")
 }
 
 func (mt *mysqlTest) TestInsertFromSelect() {

--- a/dialect/postgres/postgres.go
+++ b/dialect/postgres/postgres.go
@@ -4,6 +4,8 @@ import (
 	"github.com/doug-martin/goqu/v9"
 )
 
+const DialectName = "postgres"
+
 func DialectOptions() *goqu.SQLDialectOptions {
 	do := goqu.DefaultDialectOptions()
 	do.PlaceHolderFragment = []byte("$")
@@ -12,5 +14,5 @@ func DialectOptions() *goqu.SQLDialectOptions {
 }
 
 func init() {
-	goqu.RegisterDialect("postgres", DialectOptions())
+	goqu.RegisterDialect(DialectName, DialectOptions())
 }

--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -7,6 +7,8 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 )
 
+const DialectName = "sqlite3"
+
 func DialectOptions() *goqu.SQLDialectOptions {
 	opts := goqu.DefaultDialectOptions()
 
@@ -72,5 +74,5 @@ func DialectOptions() *goqu.SQLDialectOptions {
 }
 
 func init() {
-	goqu.RegisterDialect("sqlite3", DialectOptions())
+	goqu.RegisterDialect(DialectName, DialectOptions())
 }

--- a/dialect/sqlite3/sqlite3_dialect_test.go
+++ b/dialect/sqlite3/sqlite3_dialect_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/stretchr/testify/suite"
 )
@@ -23,7 +24,7 @@ type (
 )
 
 func (sds *sqlite3DialectSuite) GetDs(table string) *goqu.SelectDataset {
-	return goqu.Dialect("sqlite3").From(table)
+	return goqu.Dialect(sqlite3.DialectName).From(table)
 }
 
 func (sds *sqlite3DialectSuite) assertSQL(cases ...sqlTestCase) {

--- a/dialect/sqlserver/sqlserver.go
+++ b/dialect/sqlserver/sqlserver.go
@@ -6,6 +6,8 @@ import (
 	"github.com/doug-martin/goqu/v9/sqlgen"
 )
 
+const DialectName = "sqlserver"
+
 func DialectOptions() *goqu.SQLDialectOptions {
 	opts := goqu.DefaultDialectOptions()
 
@@ -95,5 +97,5 @@ func DialectOptions() *goqu.SQLDialectOptions {
 }
 
 func init() {
-	goqu.RegisterDialect("sqlserver", DialectOptions())
+	goqu.RegisterDialect(DialectName, DialectOptions())
 }

--- a/dialect/sqlserver/sqlserver_dialect_test.go
+++ b/dialect/sqlserver/sqlserver_dialect_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/dialect/sqlserver"
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/stretchr/testify/suite"
 )
@@ -22,7 +23,7 @@ type (
 )
 
 func (sds *sqlserverDialectSuite) GetDs(table string) *goqu.SelectDataset {
-	return goqu.Dialect("sqlserver").From(table)
+	return goqu.Dialect(sqlserver.DialectName).From(table)
 }
 
 func (sds *sqlserverDialectSuite) assertSQL(cases ...sqlTestCase) {

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -18,11 +18,11 @@ import (
   "fmt"
   "github.com/doug-martin/goqu/v9"
   // import the dialect
-  _ "github.com/doug-martin/goqu/v9/dialect/postgres"
+  "github.com/doug-martin/goqu/v9/dialect/postgres"
 )
 
 // look up the dialect
-dialect := goqu.Dialect("postgres")
+dialect := goqu.Dialect(postgres.DialectName)
 
 // use dialect.From to get a dataset to build your SQL
 ds := dialect.From("test").Where(goqu.Ex{"id": 10})
@@ -46,11 +46,11 @@ import (
   "fmt"
   "github.com/doug-martin/goqu/v9"
   // import the dialect
-  _ "github.com/doug-martin/goqu/v9/dialect/mysql"
+  "github.com/doug-martin/goqu/v9/dialect/mysql"
 )
 
 // look up the dialect
-dialect := goqu.Dialect("mysql")
+dialect := goqu.Dialect(mysql.DialectName)
 
 // use dialect.From to get a dataset to build your SQL
 ds := dialect.From("test").Where(goqu.Ex{"id": 10})
@@ -74,11 +74,11 @@ import (
   "fmt"
   "github.com/doug-martin/goqu/v9"
   // import the dialect
-  _ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
+  "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 )
 
 // look up the dialect
-dialect := goqu.Dialect("sqlite3")
+dialect := goqu.Dialect(sqlite3.DialectName)
 
 // use dialect.From to get a dataset to build your SQL
 ds := dialect.From("test").Where(goqu.Ex{"id": 10})
@@ -102,11 +102,11 @@ import (
   "fmt"
   "github.com/doug-martin/goqu/v9"
   // import the dialect
-  _ "github.com/doug-martin/goqu/v9/dialect/sqlserver"
+  "github.com/doug-martin/goqu/v9/dialect/sqlserver"
 )
 
 // look up the dialect
-dialect := goqu.Dialect("sqlserver")
+dialect := goqu.Dialect(sqlserver.DialectName)
 
 // use dialect.From to get a dataset to build your SQL
 ds := dialect.From("test").Where(goqu.Ex{"id": 10})
@@ -123,7 +123,7 @@ Output:
 SELECT * FROM "test" WHERE "id" = 10 []
 ```
 
-### Executing Queries 
+### Executing Queries
 
 You can also create a `goqu.Database` instance to query records.
 
@@ -133,11 +133,11 @@ In the example below notice that we imported the dialect and driver for side eff
 import (
   "database/sql"
   "github.com/doug-martin/goqu/v9"
-  _ "github.com/doug-martin/goqu/v9/dialect/postgres"
+  "github.com/doug-martin/goqu/v9/dialect/postgres"
   _ "github.com/lib/pq"
 )
 
-dialect := goqu.Dialect("postgres")
+dialect := goqu.Dialect(postgres.DialectName)
 
 pgDb, err := sql.Open("postgres", "user=postgres dbname=goqupostgres sslmode=disable ")
 if err != nil {
@@ -193,4 +193,3 @@ SELECT * FROM `test` []
 ```
 
 For more examples look at [`postgres`](./dialect/postgres/postgres.go), [`mysql`](./dialect/mysql/mysql.go) and [`sqlite3`](./dialect/sqlite3/sqlite3.go) for examples.
-


### PR DESCRIPTION
As of now, to register a dialect you have to import the package only
for the side-effects and call `goqu.Dialect` with a name to use
it. This commit proposes declaring the dialect name in a const so we
can use it when fetching the dialect, thus ensuring the package with
the init is being imported.

This means that, instead of doing this:

```go
package bla
import (
	"github.com/doug-martin/goqu/v9"
	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
)

var dialect = goqu.Dialect("postgres")
```

we can do this:

```go
package bla
import (
	"github.com/doug-martin/goqu/v9"
	"github.com/doug-martin/goqu/v9/dialect/postgres"
)

var dialect = goqu.Dialect(postgres.DialectName)
```

Not a lot of difference, but it makes clear which import is
registering the dialect.

PS: A side effect is that it could reduce the debugging time when you
misspell the dialect name.