### PR TITLE
Add Array Join support

### DIFF
--- a/exp/exp.go
+++ b/exp/exp.go
@@ -533,6 +533,7 @@ const (
 	NaturalRightJoinType
 	NaturalFullJoinType
 	CrossJoinType
+	ArrayJoinType
 
 	UsingJoinCondType JoinConditionType = iota
 	OnJoinCondType
@@ -729,6 +730,8 @@ func (jt JoinType) String() string {
 		return "NaturalFullJoinType"
 	case CrossJoinType:
 		return "CrossJoinType"
+	case ArrayJoinType:
+		return "ArrayJoinType"
 	}
 	return fmt.Sprintf("%d", jt)
 }

--- a/select_dataset.go
+++ b/select_dataset.go
@@ -343,6 +343,11 @@ func (sd *SelectDataset) CrossJoin(table exp.Expression) *SelectDataset {
 	return sd.joinTable(exp.NewUnConditionedJoinExpression(exp.CrossJoinType, table))
 }
 
+// Adds a CROSS JOIN clause. See examples.
+func (sd *SelectDataset) ArrayJoin(expression exp.Expression) *SelectDataset {
+	return sd.joinTable(exp.NewUnConditionedJoinExpression(exp.ArrayJoinType, expression))
+}
+
 // Joins this Datasets table with another
 func (sd *SelectDataset) joinTable(join exp.JoinExpression) *SelectDataset {
 	return sd.copy(sd.clauses.JoinsAppend(join))

--- a/select_dataset_test.go
+++ b/select_dataset_test.go
@@ -625,6 +625,24 @@ func (sds *selectDatasetSuite) TestCrossJoin() {
 	)
 }
 
+func (sds *selectDatasetSuite) TestArrayJoin() {
+	bd := goqu.From("test")
+	sds.assertCases(
+		selectTestCase{
+			ds: bd.ArrayJoin(goqu.T("foo")),
+			clauses: exp.NewSelectClauses().
+				SetFrom(exp.NewColumnListExpression("test")).
+				JoinsAppend(
+					exp.NewUnConditionedJoinExpression(exp.ArrayJoinType, goqu.T("foo")),
+				),
+		},
+		selectTestCase{
+			ds:      bd,
+			clauses: exp.NewSelectClauses().SetFrom(exp.NewColumnListExpression("test")),
+		},
+	)
+}
+
 func (sds *selectDatasetSuite) TestWhere() {
 	w := goqu.Ex{"a": 1}
 	w2 := goqu.Ex{"b": "c"}

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -547,6 +547,7 @@ func DefaultDialectOptions() *SQLDialectOptions {
 			exp.NaturalRightJoinType: []byte(" NATURAL RIGHT JOIN "),
 			exp.NaturalFullJoinType:  []byte(" NATURAL FULL JOIN "),
 			exp.CrossJoinType:        []byte(" CROSS JOIN "),
+			exp.ArrayJoinType:        []byte(" ARRAY JOIN "),
 		},
 
 		TimeFormat: time.RFC3339Nano,


### PR DESCRIPTION
i've added support for this
https://clickhouse.com/docs/en/sql-reference/statements/select/array-join

May be it should be added to some dialect explicitly, because ClickHouse has a lot of custom sql syntax and features. But implementing flexible analytical query builder i lacked really only Array Join operator