### PR TITLE
Add option to support uppercase identifiers

### DIFF
--- a/delete_dataset.go
+++ b/delete_dataset.go
@@ -210,12 +210,12 @@ func (dd *DeleteDataset) ToSQL() (sql string, params []interface{}, err error) {
 
 // Appends this Dataset's DELETE statement to the SQLBuilder
 // This is used internally when using deletes in CTEs
-func (dd *DeleteDataset) AppendSQL(b sb.SQLBuilder) {
+func (dd *DeleteDataset) AppendSQL(b sb.SQLBuilder, dialect string) {
 	if dd.err != nil {
 		b.SetError(dd.err)
 		return
 	}
-	dd.dialect.ToDeleteSQL(b, dd.GetClauses())
+	GetDialect(dialect).ToDeleteSQL(b, dd.GetClauses())
 }
 
 func (dd *DeleteDataset) GetAs() exp.IdentifierExpression {

--- a/dialect/oracle/oracle.go
+++ b/dialect/oracle/oracle.go
@@ -26,7 +26,8 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.SurroundLimitWithParentheses = true
 
 	opts.PlaceHolderFragment = []byte(":")
-	opts.QuoteIdentifiers = false
+	opts.QuoteIdentifiers = true
+	opts.UppercaseIdentifiers = true
 	opts.IncludePlaceholderNum = true
 	opts.DefaultValuesFragment = []byte("")
 	opts.True = []byte("1")

--- a/dialect/oracle/oracle.go
+++ b/dialect/oracle/oracle.go
@@ -1,0 +1,57 @@
+package oracle
+
+import (
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/sqlgen"
+)
+
+func DialectOptions() *goqu.SQLDialectOptions {
+	opts := goqu.DefaultDialectOptions()
+
+	opts.BooleanDataTypeSupported = false
+	opts.UseLiteralIsBools = false
+
+	opts.SupportsReturn = false
+	opts.SupportsOrderByOnUpdate = false
+	opts.SupportsLimitOnUpdate = false
+	opts.SupportsLimitOnDelete = false
+	opts.SupportsOrderByOnDelete = true
+	opts.SupportsConflictUpdateWhere = false
+	opts.SupportsInsertIgnoreSyntax = false
+	opts.SupportsConflictTarget = false
+	opts.SupportsWithCTE = false
+	opts.SupportsWithCTERecursive = false
+	opts.SupportsDistinctOn = false
+	opts.SupportsWindowFunction = false
+	opts.SurroundLimitWithParentheses = true
+
+	opts.PlaceHolderFragment = []byte(":")
+	opts.QuoteIdentifiers = false
+	opts.IncludePlaceholderNum = true
+	opts.DefaultValuesFragment = []byte("")
+	opts.True = []byte("1")
+	opts.False = []byte("0")
+
+	opts.FetchFragment = []byte(" FETCH FIRST ")
+
+	opts.SelectSQLOrder = []sqlgen.SQLFragmentType{
+		sqlgen.CommonTableSQLFragment,
+		sqlgen.SelectSQLFragment,
+		sqlgen.FromSQLFragment,
+		sqlgen.JoinSQLFragment,
+		sqlgen.WhereSQLFragment,
+		sqlgen.GroupBySQLFragment,
+		sqlgen.HavingSQLFragment,
+		sqlgen.WindowSQLFragment,
+		sqlgen.CompoundsSQLFragment,
+		sqlgen.OrderWithOffsetFetchSQLFragment,
+		sqlgen.ForSQLFragment,
+	}
+
+	return opts
+}
+
+func init() {
+	goqu.RegisterDialect("oracle", DialectOptions())
+	goqu.RegisterDialect("oci8", DialectOptions())
+}

--- a/dialect/sqlserver/sqlserver.go
+++ b/dialect/sqlserver/sqlserver.go
@@ -64,7 +64,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 
 	opts.SelectSQLOrder = []sqlgen.SQLFragmentType{
 		sqlgen.CommonTableSQLFragment,
-		sqlgen.SelectWithLimitSQLFragment,
+		sqlgen.SelectSQLFragment,
 		sqlgen.FromSQLFragment,
 		sqlgen.JoinSQLFragment,
 		sqlgen.WhereSQLFragment,

--- a/exec/scanner.go
+++ b/exec/scanner.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"database/sql"
 	"reflect"
+	"strings"
 
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/doug-martin/goqu/v9/internal/errors"
@@ -69,7 +70,7 @@ func (s *scanner) ScanStruct(i interface{}) error {
 
 	scans := make([]interface{}, 0, len(s.columns))
 	for _, col := range s.columns {
-		data, ok := s.columnMap[col]
+		data, ok := s.columnMap[strings.ToLower(col)]
 		switch {
 		case !ok:
 			return unableToFindFieldError(col)
@@ -84,7 +85,7 @@ func (s *scanner) ScanStruct(i interface{}) error {
 
 	record := exp.Record{}
 	for index, col := range s.columns {
-		record[col] = scans[index]
+		record[strings.ToLower(col)] = scans[index]
 	}
 
 	util.AssignStructVals(i, record, s.columnMap)

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -177,7 +177,7 @@ type (
 
 	AppendableExpression interface {
 		Expression
-		AppendSQL(b sb.SQLBuilder)
+		AppendSQL(b sb.SQLBuilder, dialect string)
 		// Returns the alias value as an identiier expression
 		GetAs() IdentifierExpression
 

--- a/insert_dataset.go
+++ b/insert_dataset.go
@@ -233,12 +233,12 @@ func (id *InsertDataset) ToSQL() (sql string, params []interface{}, err error) {
 
 // Appends this Dataset's INSERT statement to the SQLBuilder
 // This is used internally when using inserts in CTEs
-func (id *InsertDataset) AppendSQL(b sb.SQLBuilder) {
+func (id *InsertDataset) AppendSQL(b sb.SQLBuilder, dialect string) {
 	if id.err != nil {
 		b.SetError(id.err)
 		return
 	}
-	id.dialect.ToInsertSQL(b, id.GetClauses())
+	GetDialect(dialect).ToInsertSQL(b, id.GetClauses())
 }
 
 func (id *InsertDataset) GetAs() exp.IdentifierExpression {

--- a/select_dataset.go
+++ b/select_dataset.go
@@ -551,12 +551,12 @@ func (sd *SelectDataset) Executor() exec.QueryExecutor {
 
 // Appends this Dataset's SELECT statement to the SQLBuilder
 // This is used internally for sub-selects by the dialect
-func (sd *SelectDataset) AppendSQL(b sb.SQLBuilder) {
+func (sd *SelectDataset) AppendSQL(b sb.SQLBuilder, dialect string) {
 	if sd.err != nil {
 		b.SetError(sd.err)
 		return
 	}
-	sd.dialect.ToSelectSQL(b, sd.GetClauses())
+	GetDialect(dialect).ToSelectSQL(b, sd.GetClauses())
 }
 
 func (sd *SelectDataset) ReturnsColumns() bool {

--- a/select_dataset_test.go
+++ b/select_dataset_test.go
@@ -1189,7 +1189,7 @@ func (sds *selectDatasetSuite) TestAppendSQL() {
 	c := ds.GetClauses()
 	sqlB := sb.NewSQLBuilder(false)
 	md.On("ToSelectSQL", sqlB, c).Return(nil).Once()
-	ds.AppendSQL(sqlB)
+	ds.AppendSQL(sqlB, md.Dialect())
 	sds.NoError(sqlB.Error())
 	md.AssertExpectations(sds.T())
 }

--- a/sqlgen/common_sql_generator.go
+++ b/sqlgen/common_sql_generator.go
@@ -113,16 +113,16 @@ func (csg *commonSQLGenerator) OrderWithOffsetFetchSQL(
 	}
 
 	csg.OrderSQL(b, order)
-	if offset > 0 {
+	if offset >= 0 {
 		b.Write(csg.dialectOptions.OffsetFragment)
 		csg.esg.Generate(b, offset)
 		b.Write([]byte(" ROWS"))
 
-		if limit != nil {
-			b.Write(csg.dialectOptions.FetchFragment)
-			csg.esg.Generate(b, limit)
-			b.Write([]byte(" ROWS ONLY"))
-		}
+	}
+	if limit != nil {
+		b.Write(csg.dialectOptions.FetchFragment)
+		csg.esg.Generate(b, limit)
+		b.Write([]byte(" ROWS ONLY"))
 	}
 }
 
@@ -136,6 +136,9 @@ func (csg *commonSQLGenerator) LimitSQL(b sb.SQLBuilder, limit interface{}) {
 		csg.esg.Generate(b, limit)
 		if csg.dialectOptions.SurroundLimitWithParentheses {
 			b.WriteRunes(csg.dialectOptions.RightParenRune)
+		}
+		if csg.dialectOptions.LimitEndFragment != nil {
+			b.Write(csg.dialectOptions.LimitEndFragment)
 		}
 	}
 }

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -235,17 +235,25 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 	}
 	schema, table, col := ident.GetSchema(), ident.GetTable(), ident.GetCol()
 	if schema != esg.dialectOptions.EmptyString {
-		b.WriteRunes(esg.dialectOptions.QuoteRune).
-			WriteStrings(schema).
-			WriteRunes(esg.dialectOptions.QuoteRune)
+		if esg.dialectOptions.QuoteIdentifiers {
+			b.WriteRunes(esg.dialectOptions.QuoteRune)
+		}
+		b.WriteStrings(schema)
+		if esg.dialectOptions.QuoteIdentifiers {
+			b.WriteRunes(esg.dialectOptions.QuoteRune)
+		}
 	}
 	if table != esg.dialectOptions.EmptyString {
 		if schema != esg.dialectOptions.EmptyString {
 			b.WriteRunes(esg.dialectOptions.PeriodRune)
 		}
-		b.WriteRunes(esg.dialectOptions.QuoteRune).
-			WriteStrings(table).
-			WriteRunes(esg.dialectOptions.QuoteRune)
+		if esg.dialectOptions.QuoteIdentifiers {
+			b.WriteRunes(esg.dialectOptions.QuoteRune)
+		}
+		b.WriteStrings(table)
+		if esg.dialectOptions.QuoteIdentifiers {
+			b.WriteRunes(esg.dialectOptions.QuoteRune)
+		}
 	}
 	switch t := col.(type) {
 	case nil:
@@ -254,9 +262,13 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 			if table != esg.dialectOptions.EmptyString || schema != esg.dialectOptions.EmptyString {
 				b.WriteRunes(esg.dialectOptions.PeriodRune)
 			}
-			b.WriteRunes(esg.dialectOptions.QuoteRune).
-				WriteStrings(t).
-				WriteRunes(esg.dialectOptions.QuoteRune)
+			if esg.dialectOptions.QuoteIdentifiers {
+				b.WriteRunes(esg.dialectOptions.QuoteRune)
+			}
+			b.WriteStrings(t)
+			if esg.dialectOptions.QuoteIdentifiers {
+				b.WriteRunes(esg.dialectOptions.QuoteRune)
+			}
 		}
 	case exp.LiteralExpression:
 		if table != esg.dialectOptions.EmptyString || schema != esg.dialectOptions.EmptyString {

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -238,7 +239,11 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
-		b.WriteStrings(schema)
+		if esg.dialectOptions.UppercaseIdentifiers {
+			b.WriteStrings(strings.ToUpper(schema))
+		} else {
+			b.WriteStrings(schema)
+		}
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
@@ -250,7 +255,11 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
-		b.WriteStrings(table)
+		if esg.dialectOptions.UppercaseIdentifiers {
+			b.WriteStrings(strings.ToUpper(table))
+		} else {
+			b.WriteStrings(table)
+		}
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
@@ -265,7 +274,11 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 			if esg.dialectOptions.QuoteIdentifiers {
 				b.WriteRunes(esg.dialectOptions.QuoteRune)
 			}
-			b.WriteStrings(t)
+			if esg.dialectOptions.UppercaseIdentifiers {
+				b.WriteStrings(strings.ToUpper(t))
+			} else {
+				b.WriteStrings(t)
+			}
 			if esg.dialectOptions.QuoteIdentifiers {
 				b.WriteRunes(esg.dialectOptions.QuoteRune)
 			}

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -219,7 +219,7 @@ func (esg *expressionSQLGenerator) placeHolderSQL(b sb.SQLBuilder, i interface{}
 // Generates creates the sql for a sub select on a Dataset
 func (esg *expressionSQLGenerator) appendableExpressionSQL(b sb.SQLBuilder, a exp.AppendableExpression) {
 	b.WriteRunes(esg.dialectOptions.LeftParenRune)
-	a.AppendSQL(b)
+	a.AppendSQL(b, esg.dialect)
 	b.WriteRunes(esg.dialectOptions.RightParenRune)
 	if a.GetAs() != nil {
 		b.Write(esg.dialectOptions.AsFragment)
@@ -692,10 +692,10 @@ func (esg *expressionSQLGenerator) compoundExpressionSQL(b sb.SQLBuilder, compou
 	}
 	if esg.dialectOptions.WrapCompoundsInParens {
 		b.WriteRunes(esg.dialectOptions.LeftParenRune)
-		compound.RHS().AppendSQL(b)
+		compound.RHS().AppendSQL(b, esg.dialect)
 		b.WriteRunes(esg.dialectOptions.RightParenRune)
 	} else {
-		compound.RHS().AppendSQL(b)
+		compound.RHS().AppendSQL(b, esg.dialect)
 	}
 }
 

--- a/sqlgen/expression_sql_generator_test.go
+++ b/sqlgen/expression_sql_generator_test.go
@@ -48,7 +48,7 @@ func (tae *testAppendableExpression) ReturnsColumns() bool {
 	return tae.returnsColumns
 }
 
-func (tae *testAppendableExpression) AppendSQL(b sb.SQLBuilder) {
+func (tae *testAppendableExpression) AppendSQL(b sb.SQLBuilder, dialect string) {
 	if tae.err != nil {
 		b.SetError(tae.err)
 		return

--- a/sqlgen/insert_sql_generator.go
+++ b/sqlgen/insert_sql_generator.go
@@ -126,7 +126,7 @@ func (isg *insertSQLGenerator) defaultValuesSQL(b sb.SQLBuilder) {
 
 func (isg *insertSQLGenerator) insertFromSQL(b sb.SQLBuilder, ae exp.AppendableExpression) {
 	b.WriteRunes(isg.DialectOptions().SpaceRune)
-	ae.AppendSQL(b)
+	ae.AppendSQL(b, isg.Dialect())
 }
 
 // Adds the columns list to an insert statement

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -111,6 +111,8 @@ type (
 		FetchFragment []byte
 		// The SQL LIMIT BY clause fragment(DEFAULT=[]byte(" LIMIT "))
 		LimitFragment []byte
+		// The SQL LIMIT BY end clause fragment(DEFAULT=[]byte())
+		LimitEndFragment []byte
 		// The SQL OFFSET BY clause fragment(DEFAULT=[]byte(" OFFSET "))
 		OffsetFragment []byte
 		// The SQL FOR UPDATE fragment(DEFAULT=[]byte(" FOR UPDATE "))
@@ -134,6 +136,8 @@ type (
 		// The quote rune to use when quoting identifiers(DEFAULT='"')
 		QuoteRune rune
 		// The NULL literal to use when interpolating nulls values (DEFAULT=[]byte("NULL"))
+		QuoteIdentifiers bool
+		// Whether or not to use the QuoteRune for identifiers
 		Null []byte
 		// The TRUE literal to use when interpolating bool true values (DEFAULT=[]byte("TRUE"))
 		True []byte

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -135,9 +135,11 @@ type (
 		LateralFragment []byte
 		// The quote rune to use when quoting identifiers(DEFAULT='"')
 		QuoteRune rune
-		// The NULL literal to use when interpolating nulls values (DEFAULT=[]byte("NULL"))
+		// Whether or not to use the QuoteRune for identifiers (DEFAULT=true)
 		QuoteIdentifiers bool
-		// Whether or not to use the QuoteRune for identifiers
+		// Whether or not to upcase quoted QuoteIdentifiers (DEFAULT=false)
+		UppercaseIdentifiers bool
+		// The NULL literal to use when interpolating nulls values (DEFAULT=[]byte("NULL"))
 		Null []byte
 		// The TRUE literal to use when interpolating bool true values (DEFAULT=[]byte("TRUE"))
 		True []byte
@@ -493,6 +495,7 @@ func DefaultDialectOptions() *SQLDialectOptions {
 		Null:                      []byte("NULL"),
 		True:                      []byte("TRUE"),
 		False:                     []byte("FALSE"),
+		QuoteIdentifiers:          true,
 
 		PlaceHolderFragment: []byte("?"),
 		QuoteRune:           '"',

--- a/update_dataset.go
+++ b/update_dataset.go
@@ -213,12 +213,12 @@ func (ud *UpdateDataset) ToSQL() (sql string, params []interface{}, err error) {
 
 // Appends this Dataset's UPDATE statement to the SQLBuilder
 // This is used internally when using updates in CTEs
-func (ud *UpdateDataset) AppendSQL(b sb.SQLBuilder) {
+func (ud *UpdateDataset) AppendSQL(b sb.SQLBuilder, dialect string) {
 	if ud.err != nil {
 		b.SetError(ud.err)
 		return
 	}
-	ud.dialect.ToUpdateSQL(b, ud.GetClauses())
+	GetDialect(dialect).ToUpdateSQL(b, ud.GetClauses())
 }
 
 func (ud *UpdateDataset) GetAs() exp.IdentifierExpression {


### PR DESCRIPTION
Recently, I found that Oracle joins didn't work in some cases because the join syntax requires identifiers to be quoted (i.e., "foo.bar" rather than foo.bar). A previous change I made to support Oracle ("QuotedIdentifiers" option) actually caused the problem.

However, the original reason I removed quotes from Oracle identifiers was that Oracle by default creates tables as UPPER CASE. 

```
create table foo (...) <--- This creates a table named "FOO"
```

If you use quotes around identifiers, then Oracle switches to a case-sensitive match against the table name, which fails because the tables are actually upper case:

```
select * from "table_name" <--- Fails b/c the table is actually named TABLE_NAME
```

Ideally, we would change the Oracle DDL to always use quotes:

```
create table "foo" (...) <--- This creates a table named "foo"
```

However, we have many existing databases that don't do this. So, to support that, I added an option to uppercase all identifier names:

```
UpperCaseIdentifiers = true
```

This will cause goqu to emit this SQL for Oracle:

```
select "COL_NAME" from "TABLE_NAME"...
```