### PR TITLE
feat: allow []exp.UpdateExpression as Set values.

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -262,6 +262,22 @@ Output:
 UPDATE "items" SET "address"='111 Test Addr',"name"='Test' []
 ```
 
+<a name="set-expressions"></a>
+**[Set with Expressions](https://godoc.org/github.com/doug-martin/goqu/#UpdateDataset.Set)**
+
+```go
+sql, args, _ := goqu.Update("items").Set([]exp.UpdateExpression{
+	goqu.C("name").Set("Test"),
+	goqu.C("address").Set("111 Test Addr"),
+}).ToSQL()
+fmt.Println(sql, args)
+```
+
+Output:
+```
+UPDATE "items" SET "name"='Test',"address"='111 Test Addr' []
+```
+
 <a name="from"></a>
 **[From / Multi Table](https://godoc.org/github.com/doug-martin/goqu/#UpdateDataset.From)**
 

--- a/exp/update.go
+++ b/exp/update.go
@@ -20,6 +20,10 @@ func set(col IdentifierExpression, val interface{}) UpdateExpression {
 }
 
 func NewUpdateExpressions(update interface{}) (updates []UpdateExpression, err error) {
+	if us, ok := update.([]UpdateExpression); ok {
+		updates = append(updates, us...)
+		return updates, nil
+	}
 	if u, ok := update.(UpdateExpression); ok {
 		updates = append(updates, u)
 		return updates, nil

--- a/update_dataset_example_test.go
+++ b/update_dataset_example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	_ "github.com/doug-martin/goqu/v9/dialect/mysql"
+	"github.com/doug-martin/goqu/v9/exp"
 )
 
 func ExampleUpdate_withStruct() {
@@ -40,6 +41,17 @@ func ExampleUpdate_withMap() {
 
 	// Output:
 	// UPDATE "items" SET "address"='111 Test Addr',"name"='Test' []
+}
+
+func ExampleUpdate_withExpressions() {
+	sql, args, _ := goqu.Update("items").Set([]exp.UpdateExpression{
+		goqu.C("name").Set("Test"),
+		goqu.C("address").Set("111 Test Addr"),
+	}).ToSQL()
+	fmt.Println(sql, args)
+
+	// Output:
+	// UPDATE "items" SET "name"='Test',"address"='111 Test Addr' []
 }
 
 func ExampleUpdate_withSkipUpdateTag() {

--- a/update_dataset_test.go
+++ b/update_dataset_test.go
@@ -163,6 +163,18 @@ func (uds *updateDatasetSuite) TestSet() {
 			clauses: exp.NewUpdateClauses().
 				SetTable(goqu.C("items")),
 		},
+		updateTestCase{
+			ds: bd.Set([]exp.UpdateExpression{
+				goqu.C("name").Set("Test"),
+				goqu.C("address").Set("111 Test Addr"),
+			}),
+			clauses: exp.NewUpdateClauses().
+				SetTable(goqu.C("items")).
+				SetSetValues([]exp.UpdateExpression{
+					goqu.C("name").Set("Test"),
+					goqu.C("address").Set("111 Test Addr"),
+				}),
+		},
 	)
 }
 


### PR DESCRIPTION
Usually, a update looks like this:

```go
sql, _, _ := goqu.Update("items").Set(
	goqu.Record{"name": "Test", "address": "111 Test Addr"},
).ToSQL()
```

Then you will get:

```sql
UPDATE "items" SET "address"='111 Test Addr',"name"='Test'
```

Note the fields are sorted. 

And now we can update like this:

```go
sql, _, _ := goqu.Update("items").Set([]exp.UpdateExpression{
	goqu.C("name").Set("Test"),
	goqu.C("address").Set("111 Test Addr"),
}).ToSQL()
```

Then you will get:

```sql
UPDATE "items" SET "name"='Test',"address"='111 Test Addr'
```

Note that the field "name"  is now in front of the field "address".
