### PR TITLE
Check spelling of the documentation

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -47,7 +47,7 @@ The [`TxDatabase`](http://godoc.org/github.com/doug-martin/goqu/#TxDatabase)  al
 
 #### Wrap
 
-The [`TxDatabase.Wrap`](http://godoc.org/github.com/doug-martin/goqu/#TxDatabase.Wrap) is a convience method for automatically handling `COMMIT` and `ROLLBACK`
+The [`TxDatabase.Wrap`](http://godoc.org/github.com/doug-martin/goqu/#TxDatabase.Wrap) is a convenience method for automatically handling `COMMIT` and `ROLLBACK`
 
 ```go
 tx, err := db.Begin()
@@ -73,5 +73,5 @@ To enable trace logging of SQL statements use the [`Database.Logger`](http://god
 
 **NOTE** The logger must implement the [`Logger`](http://godoc.org/github.com/doug-martin/goqu/#Logger) interface
 
-**NOTE** If you start a transaction using a database your set a logger on the transaction will inherit that logger automatically
+**NOTE** If you start a transaction using a database, your set a logger on the transaction will inherit that logger automatically
 

--- a/docs/deleting.md
+++ b/docs/deleting.md
@@ -219,7 +219,7 @@ DELETE FROM "test" RETURNING "test".*
 **[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#DeleteDataset.SetError)**
 
 Sometimes while building up a query with goqu you will encounter situations where certain
-preconditions are not met or some end-user contraint has been violated. While you could
+preconditions are not met or some end-user constraint has been violated. While you could
 track this error case separately, goqu provides a convenient built-in mechanism to set an
 error on a dataset if one has not already been set to simplify query building.
 

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -7,7 +7,7 @@
 * [`S`](#S) - An Identifier that represents a schema. With a schema identifier you can fully qualify tables and columns.
 * [`T`](#T) - An Identifier that represents a Table. With a Table identifier you can fully qualify columns.
 * [`C`](#C) - An Identifier that represents a Column. See the docs for more examples
-* [`I`](#I) - An Identifier represents a schema, table, or column or any combination. I parses identifiers seperated by a . character.
+* [`I`](#I) - An Identifier represents a schema, table, or column or any combination. I parses identifiers separated by a . character.
 * [`L`](#L) - An SQL literal.
 * [`V`](#V) - An Value to be used in SQL. 
 * [`And`](#and) - AND multiple expressions together.
@@ -143,7 +143,7 @@ fmt.Println(sql)
 <a name="I"></a>
 **[`I()`](https://godoc.org/github.com/doug-martin/goqu#I)** 
 
-An Identifier represents a schema, table, or column or any combination. `I` parses identifiers seperated by a `.` character.
+An Identifier represents a schema, table, or column or any combination. `I` parses identifiers separated by a `.` character.
 
 ```go
 // with three parts it is assumed you have provided a schema, table and column

--- a/docs/inserting.md
+++ b/docs/inserting.md
@@ -437,7 +437,7 @@ INSERT INTO "test" ("a", "b") VALUES ('a', 'b') RETURNING "test".*
 **[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#InsertDataset.SetError)**
 
 Sometimes while building up a query with goqu you will encounter situations where certain
-preconditions are not met or some end-user contraint has been violated. While you could
+preconditions are not met or some end-user constraint has been violated. While you could
 track this error case separately, goqu provides a convenient built-in mechanism to set an
 error on a dataset if one has not already been set to simplify query building.
 

--- a/docs/selecting.md
+++ b/docs/selecting.md
@@ -17,10 +17,10 @@
   * [`ForUpdate`](#forupdate)
 * Executing Queries
   * [`ScanStructs`](#scan-structs) - Scans rows into a slice of structs
-  * [`ScanStruct`](#scan-struct) - Scans a row into a slice a struct, returns false if a row wasnt found
+  * [`ScanStruct`](#scan-struct) - Scans a row into a slice a struct, returns false if a row wasn't found
   * [`ScanVals`](#scan-vals)- Scans a rows of 1 column into a slice of primitive values
-  * [`ScanVal`](#scan-val) - Scans a row of 1 column into a primitive value, returns false if a row wasnt found.
-  * [`Scanner`](#scanner) - Allows you to interatively scan rows into structs or values.
+  * [`ScanVal`](#scan-val) - Scans a row of 1 column into a primitive value, returns false if a row wasn't found.
+  * [`Scanner`](#scanner) - Allows you to iteratively scan rows into structs or values.
   * [`Count`](#count) - Returns the count for the current query
   * [`Pluck`](#pluck) - Selects a single column and stores the results into a slice of primitive values
 
@@ -839,7 +839,7 @@ SELECT ROW_NUMBER() OVER "w" FROM "test" WINDOW "w" AS (PARTITION BY "a" ORDER B
 **[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#SelectDataset.SetError)**
 
 Sometimes while building up a query with goqu you will encounter situations where certain
-preconditions are not met or some end-user contraint has been violated. While you could
+preconditions are not met or some end-user constraint has been violated. While you could
 track this error case separately, goqu provides a convenient built-in mechanism to set an
 error on a dataset if one has not already been set to simplify query building.
 
@@ -989,7 +989,7 @@ ds := db.
 		"goqu_user.id",
 		"goqu_user.first_name",
 		"goqu_user.last_name",
-		// alias the fully qualified identifier `C` is important here so it doesnt parse it
+		// alias the fully qualified identifier `C` is important here so it doesn't parse it
 		goqu.I("user_role.user_id").As(goqu.C("user_role.user_id")),
 		goqu.I("user_role.name").As(goqu.C("user_role.name")),
 	).
@@ -1009,7 +1009,7 @@ for _, u := range users {
 <a name="scan-struct"></a>
 **[`ScanStruct`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanStruct)**
 
-Scans a row into a slice a struct, returns false if a row wasnt found
+Scans a row into a slice a struct, returns false if a row wasn't found
 
 **NOTE** [`ScanStruct`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanStruct) will only select the columns that can be scanned in to the struct unless you have explicitly selected certain columns.
 
@@ -1091,7 +1091,7 @@ ds := db.
 		"goqu_user.id",
 		"goqu_user.first_name",
 		"goqu_user.last_name",
-		// alias the fully qualified identifier `C` is important here so it doesnt parse it
+		// alias the fully qualified identifier `C` is important here so it doesn't parse it
 		goqu.I("user_role.user_id").As(goqu.C("user_role.user_id")),
 		goqu.I("user_role.name").As(goqu.C("user_role.name")),
 	).
@@ -1164,7 +1164,7 @@ fmt.Printf("\n%+v", ids)
 <a name="scan-val"></a>
 [`ScanVal`](http://godoc.org/github.com/doug-martin/goqu#SelectDataset.ScanVal)
 
-Scans a row of 1 column into a primitive value, returns false if a row wasnt found.
+Scans a row of 1 column into a primitive value, returns false if a row wasn't found.
 
 **Note** when using the dataset a `LIMIT` of 1 is automatically applied.
 ```go

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -498,7 +498,7 @@ UPDATE "test" SET "foo"='bar' RETURNING "test".*
 **[`SetError`](https://godoc.org/github.com/doug-martin/goqu/#UpdateDataset.SetError)**
 
 Sometimes while building up a query with goqu you will encounter situations where certain
-preconditions are not met or some end-user contraint has been violated. While you could
+preconditions are not met or some end-user constraint has been violated. While you could
 track this error case separately, goqu provides a convenient built-in mechanism to set an
 error on a dataset if one has not already been set to simplify query building.
 

--- a/docs/version_migration.md
+++ b/docs/version_migration.md
@@ -6,14 +6,14 @@
 <a name="v8"></a>
 ### `v7 to v8`
 
-A major change the the API was made in `v8` to seperate concerns between the different SQL statement types. 
+A major change the the API was made in `v8` to separate concerns between the different SQL statement types. 
 
 **Why the change?**
 
 1. There were feature requests that could not be cleanly implemented with everything in a single dataset. 
 2. Too much functionality was encapsulated in a single datastructure.
     * It was unclear what methods could be used for each SQL statement type.
-    * Changing a feature for one statement type had the possiblity of breaking another statement type.
+    * Changing a feature for one statement type had the possibility of breaking another statement type.
     * Test coverage was decent but was almost solely concerned about SELECT statements, breaking them up allowed for focused testing on each statement type.
     * Most the SQL generation methods (`ToInsertSQL`, `ToUpdateSQL` etc.) took arguments which lead to an ugly API that was not uniform for each statement type, and proved to be inflexible.
 


### PR DESCRIPTION
After reviewing the documentation, I noticed a  few spelling errors. This pull request fixes them.
Kind regards.