### PR TITLE
ScanStruct support for structs with Interface types

### DIFF
--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -211,7 +211,7 @@ func GetColumnMap(i interface{}) (ColumnMap, error) {
 	structMapCacheLock.Lock()
 	defer structMapCacheLock.Unlock()
 	if _, ok := structMapCache[t]; !ok {
-		structMapCache[t] = newColumnMap(t, []int{}, []string{})
+		structMapCache[t] = newColumnMap(val, t, []int{}, []string{})
 	}
 	return structMapCache[t], nil
 }


### PR DESCRIPTION
This PR serves both as an issue report and a preliminary attempt to fix a problem in the `ScanStruct` method of `goqu`. The method encounters errors when dealing with structs that contain interface types, specifically those implementing the `sql.Scanner` interface.

The `ScanStruct` method fails with errors like the following when it encounters an interface type within a struct:
```
sql: Scan error on column index 1, name "value": unsupported Scan, storing driver.Value type string into type *sql.Scanner
```
This issue arises because the `newColumnMap` function assigns the interface type to `GoType` rather than the concrete type of the object in use.
I've made an attempt to resolve this by detecting if a struct field's type is `Interface` and then replacing `f.Type` with `concreteType`. This approach seems to work, but it introduces a potential issue where the scanner might reuse the same type for subsequent scans, when the interface could be implemented by different objects (the second testcase with `NullInt32` object).

Well, the question is, if I am not overthinking it :)

So, what do you think?
