### PR TITLE
Uint support

### DIFF
--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -92,6 +92,12 @@ func (esg *expressionSQLGenerator) Generate(b sb.SQLBuilder, val interface{}) {
 		esg.literalInt(b, int64(v))
 	case int64:
 		esg.literalInt(b, v)
+	case uint:
+		esg.literalUint(b, uint64(v))
+	case uint32:
+		esg.literalUint(b, uint64(v))
+	case uint64:
+		esg.literalUint(b, v)
 	case float32:
 		esg.literalFloat(b, float64(v))
 	case float64:
@@ -145,7 +151,7 @@ func (esg *expressionSQLGenerator) reflectSQL(b sb.SQLBuilder, val interface{}) 
 	case util.IsInt(valKind):
 		esg.Generate(b, v.Int())
 	case util.IsUint(valKind):
-		esg.Generate(b, int64(v.Uint()))
+		esg.Generate(b, v.Uint())
 	case util.IsFloat(valKind):
 		esg.Generate(b, v.Float())
 	case util.IsString(valKind):
@@ -324,6 +330,15 @@ func (esg *expressionSQLGenerator) literalInt(b sb.SQLBuilder, i int64) {
 		return
 	}
 	b.WriteStrings(strconv.FormatInt(i, 10))
+}
+
+// Generates SQL for an uint value
+func (esg *expressionSQLGenerator) literalUint(b sb.SQLBuilder, i uint64) {
+	if b.IsPrepared() {
+		esg.placeHolderSQL(b, i)
+		return
+	}
+	b.WriteStrings(strconv.FormatUint(i, 10))
 }
 
 // Generates SQL for a string

--- a/sqlgen/expression_sql_generator_test.go
+++ b/sqlgen/expression_sql_generator_test.go
@@ -179,10 +179,6 @@ func (esgs *expressionSQLGeneratorSuite) TestGenerate_IntTypes() {
 		int16(10),
 		int32(10),
 		int64(10),
-		uint(10),
-		uint16(10),
-		uint32(10),
-		uint64(10),
 	}
 	for _, i := range ints {
 		esgs.assertCases(
@@ -195,6 +191,27 @@ func (esgs *expressionSQLGeneratorSuite) TestGenerate_IntTypes() {
 		sqlgen.NewExpressionSQLGenerator("test", sqlgen.DefaultDialectOptions()),
 		expressionTestCase{val: &i, sql: "0"},
 		expressionTestCase{val: &i, sql: "?", isPrepared: true, args: []interface{}{i}},
+	)
+}
+
+func (esgs *expressionSQLGeneratorSuite) TestGenerate_UintTypes() {
+	var u uint64
+	esgs.assertCases(
+		sqlgen.NewExpressionSQLGenerator("test", sqlgen.DefaultDialectOptions()),
+		expressionTestCase{val: uint(65535), sql: "65535"},
+		expressionTestCase{val: uint(65535), sql: "?", isPrepared: true, args: []interface{}{uint64(65535)}},
+
+		expressionTestCase{val: uint16(65535), sql: "65535"},
+		expressionTestCase{val: uint16(65535), sql: "?", isPrepared: true, args: []interface{}{uint64(65535)}},
+
+		expressionTestCase{val: uint32(4294967295), sql: "4294967295"},
+		expressionTestCase{val: uint32(4294967295), sql: "?", isPrepared: true, args: []interface{}{uint64(4294967295)}},
+
+		expressionTestCase{val: uint64(18446744073709551615), sql: "18446744073709551615"},
+		expressionTestCase{val: uint64(18446744073709551615), sql: "?", isPrepared: true, args: []interface{}{uint64(18446744073709551615)}},
+
+		expressionTestCase{val: &u, sql: "0"},
+		expressionTestCase{val: &u, sql: "?", isPrepared: true, args: []interface{}{u}},
 	)
 }
 


### PR DESCRIPTION
fix #317 

Currently, uint is cast to int64, causing overflow in some values and generating unexpected queries.

Example: (from #317)
```go
package main

import (
	"github.com/doug-martin/goqu/v9"
	_ "github.com/doug-martin/goqu/v9/dialect/mysql" // needed for mysql dialect of query builder
)

type Sample struct {
	Uint64 uint64 `db:"uint_64"`
}

func main() {
	sample := Sample{
		Uint64: 11169823557460058355,
	}
	dialect := goqu.Dialect("mysql")
	query := dialect.Insert("tableName").Rows(sample)
	sql, _, _:= query.ToSQL()
	print(sql)
}
```
expect: `INSERT INTO tableName (uint_64) VALUES (11169823557460058355)`
result: `INSERT INTO tableName (uint_64) VALUES (-7276920516249493261)`


This PR solves the problem by adding a case for uint.