### PR TITLE
feat: allow conflict targets in ON CONFLICT DO NOTHING

### DIFF
--- a/docs/inserting.md
+++ b/docs/inserting.md
@@ -7,6 +7,7 @@
   * [Insert Structs](#insert-structs)
   * [Insert Map](#insert-map)
   * [Insert From Query](#insert-from-query)
+  * [On Conflict](#onconflict)
   * [Returning](#returning)
   * [SetError](#seterror)
   * [Executing](#executing)
@@ -383,6 +384,41 @@ fmt.Println(insertSQL, args)
 Output:
 ```
 INSERT INTO "user" ("first_name", "last_name") SELECT "fn", "ln" FROM "other_table" []
+```
+
+<a name="onconflict"></a>
+**On Conflict Clause**
+
+You can handle conflicts using the `OnConflict` clause. For example, to ignore conflicts, you can use `DoNothing()`.
+
+```go
+sql, _, _ := goqu.Insert("test").
+	Rows(goqu.Record{"a": "a", "b": "b"}).
+	OnConflict(goqu.DoNothing()).
+	ToSQL()
+fmt.Println(sql)
+```
+
+Output:
+
+```
+INSERT INTO "test" ("a", "b") VALUES ('a', 'b') ON CONFLICT DO NOTHING
+```
+
+To specify columns to be used in the conflict handling
+
+```go
+sql, _, _ := goqu.Insert("test").
+	Rows(goqu.Record{"a": "a", "b": "b"}).
+	OnConflict(goqu.DoNothing().SetCols(exp.NewColumnListExpression("a", "b"))).
+	ToSQL()
+fmt.Println(sql)
+```
+
+Output:
+
+```
+INSERT INTO "test" ("a", "b") VALUES ('a', 'b') ON CONFLICT ("a", "b") DO NOTHING
 ```
 
 <a name="returning"></a>

--- a/exp/conflict.go
+++ b/exp/conflict.go
@@ -1,7 +1,9 @@
 package exp
 
 type (
-	doNothingConflict struct{}
+	doNothingConflict struct {
+		cols ColumnListExpression
+	}
 	// ConflictUpdate is the struct that represents the UPDATE fragment of an
 	// INSERT ... ON CONFLICT/ON DUPLICATE KEY DO UPDATE statement
 	conflictUpdate struct {
@@ -14,7 +16,7 @@ type (
 // Creates a conflict struct to be passed to InsertConflict to ignore constraint errors
 //
 //	InsertConflict(DoNothing(),...) -> INSERT INTO ... ON CONFLICT DO NOTHING
-func NewDoNothingConflictExpression() ConflictExpression {
+func NewDoNothingConflictExpression() ConflictNothingExpression {
 	return &doNothingConflict{}
 }
 
@@ -28,6 +30,15 @@ func (c doNothingConflict) Clone() Expression {
 
 func (c doNothingConflict) Action() ConflictAction {
 	return DoNothingConflictAction
+}
+
+func (c *doNothingConflict) SetCols(cl ColumnListExpression) ConflictNothingExpression {
+	c.cols = cl
+	return c
+}
+
+func (c doNothingConflict) Cols() ColumnListExpression {
+	return c.cols
 }
 
 // Creates a ConflictUpdate struct to be passed to InsertConflict

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -275,6 +275,11 @@ type (
 		Expression
 		Action() ConflictAction
 	}
+	ConflictNothingExpression interface {
+		ConflictExpression
+		SetCols(cl ColumnListExpression) ConflictNothingExpression
+		Cols() ColumnListExpression
+	}
 	ConflictUpdateExpression interface {
 		ConflictExpression
 		TargetColumn() string

--- a/expressions.go
+++ b/expressions.go
@@ -34,7 +34,7 @@ func Cast(e exp.Expression, t string) exp.CastExpression {
 // Creates a conflict struct to be passed to InsertConflict to ignore constraint errors
 //
 //	InsertConflict(DoNothing(),...) -> INSERT INTO ... ON CONFLICT DO NOTHING
-func DoNothing() exp.ConflictExpression {
+func DoNothing() exp.ConflictNothingExpression {
 	return exp.NewDoNothingConflictExpression()
 }
 

--- a/insert_dataset_test.go
+++ b/insert_dataset_test.go
@@ -359,6 +359,10 @@ func (ids *insertDatasetSuite) TestOnConflict() {
 			clauses: exp.NewInsertClauses().SetInto(goqu.C("items")).SetOnConflict(goqu.DoNothing()),
 		},
 		insertTestCase{
+			ds:      bd.OnConflict(goqu.DoNothing().SetCols(exp.NewColumnListExpression("items"))),
+			clauses: exp.NewInsertClauses().SetInto(goqu.C("items")).SetOnConflict(goqu.DoNothing().SetCols(exp.NewColumnListExpression("items"))),
+		},
+		insertTestCase{
 			ds:      bd.OnConflict(du),
 			clauses: exp.NewInsertClauses().SetInto(goqu.C("items")).SetOnConflict(du),
 		},

--- a/sqlgen/insert_sql_generator.go
+++ b/sqlgen/insert_sql_generator.go
@@ -175,6 +175,12 @@ func (isg *insertSQLGenerator) onConflictSQL(b sb.SQLBuilder, o exp.ConflictExpr
 			}
 		}
 		isg.onConflictDoUpdateSQL(b, t)
+	case exp.ConflictNothingExpression:
+		cols := t.Cols()
+		if isg.DialectOptions().SupportsConflictTarget && cols != nil {
+			isg.ConflictTargetSQL(b, cols)
+		}
+		b.Write(isg.DialectOptions().ConflictDoNothingFragment)
 	default:
 		b.Write(isg.DialectOptions().ConflictDoNothingFragment)
 	}


### PR DESCRIPTION
I have added the ability to specify conflict target columns for the `ON CONFLICT` clause, which is necessary for PostgreSQL.

Now it is possible to handle conflicts by specifying columns for conflict handling:

```go
sql, _, _ := goqu.Insert("test").
	Rows(goqu.Record{"a": "a", "b"}).
	OnConflict(goqu.DoNothing().SetCols(exp.NewColumnListExpression("a", "b"))).
	ToSQL()
fmt.Println(sql)
```

Then you will get:

```sql
INSERT INTO "test" ("a", "b") VALUES ('a', 'b') ON CONFLICT ("a", "b") DO NOTHING
```