### PR TITLE
feat: Enable custom join statements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 src
 *.iml
 coverage.*
+/.direnv/

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -533,6 +533,7 @@ const (
 	NaturalRightJoinType
 	NaturalFullJoinType
 	CrossJoinType
+	CustomJoinType
 
 	UsingJoinCondType JoinConditionType = iota
 	OnJoinCondType

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "goqu";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; };
+
+      in {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            go
+            golangci-lint
+            gotests
+            gomodifytags
+            gore
+            gotools
+
+            # LSPs
+            gopls
+          ];
+        };
+      });
+}

--- a/select_dataset.go
+++ b/select_dataset.go
@@ -343,6 +343,11 @@ func (sd *SelectDataset) CrossJoin(table exp.Expression) *SelectDataset {
 	return sd.joinTable(exp.NewUnConditionedJoinExpression(exp.CrossJoinType, table))
 }
 
+// Adds a custom join clause. See examples
+func (sd *SelectDataset) CustomJoin(expression exp.Expression) *SelectDataset {
+	return sd.joinTable(exp.NewUnConditionedJoinExpression(exp.CustomJoinType, expression))
+}
+
 // Joins this Datasets table with another
 func (sd *SelectDataset) joinTable(join exp.JoinExpression) *SelectDataset {
 	return sd.copy(sd.clauses.JoinsAppend(join))

--- a/select_dataset_example_test.go
+++ b/select_dataset_example_test.go
@@ -15,7 +15,7 @@ import (
 
 const schema = `
 		DROP TABLE IF EXISTS "user_role";
-		DROP TABLE IF EXISTS "goqu_user";	
+		DROP TABLE IF EXISTS "goqu_user";
 		CREATE  TABLE "goqu_user" (
 			"id" SERIAL PRIMARY KEY NOT NULL,
 			"first_name" VARCHAR(45) NOT NULL,
@@ -27,7 +27,7 @@ const schema = `
 			"user_id" BIGINT NOT NULL REFERENCES goqu_user(id) ON DELETE CASCADE,
 			"name" VARCHAR(45) NOT NULL,
 			"created" TIMESTAMP NOT NULL DEFAULT now()
-		); 
+		);
     `
 
 const defaultDBURI = "postgres://postgres:@localhost:5435/goqupostgres?sslmode=disable"
@@ -966,6 +966,16 @@ func ExampleSelectDataset_CrossJoin() {
 	// SELECT * FROM "test" CROSS JOIN "test2"
 	// SELECT * FROM "test" CROSS JOIN (SELECT * FROM "test2" WHERE ("amount" > 0))
 	// SELECT * FROM "test" CROSS JOIN (SELECT * FROM "test2" WHERE ("amount" > 0)) AS "t"
+}
+
+func ExampleSelectDataset_CustomJoin() {
+	join := goqu.L("ARRAY JOIN tags").As("tag")
+
+	sql, _, _ := goqu.From("test").CustomJoin(join).ToSQL()
+	fmt.Println(sql)
+
+	// Output:
+	// SELECT * FROM "test" ARRAY JOIN tags AS tag
 }
 
 func ExampleSelectDataset_FromSelf() {

--- a/select_dataset_test.go
+++ b/select_dataset_test.go
@@ -625,6 +625,20 @@ func (sds *selectDatasetSuite) TestCrossJoin() {
 	)
 }
 
+func (sds *selectDatasetSuite) TestCustomJoin() {
+	bd := goqu.From("test")
+	sds.assertCases(
+		selectTestCase{
+			ds: bd.CustomJoin(goqu.L("ARRAY JOIN tags").As("tag")),
+			clauses: exp.NewSelectClauses().
+				SetFrom(exp.NewColumnListExpression("test")).
+				JoinsAppend(
+					exp.NewUnConditionedJoinExpression(exp.CustomJoinType, goqu.L("ARRAY JOIN tags").As("tag")),
+				),
+		},
+	)
+}
+
 func (sds *selectDatasetSuite) TestWhere() {
 	w := goqu.Ex{"a": 1}
 	w2 := goqu.Ex{"b": "c"}

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -547,6 +547,7 @@ func DefaultDialectOptions() *SQLDialectOptions {
 			exp.NaturalRightJoinType: []byte(" NATURAL RIGHT JOIN "),
 			exp.NaturalFullJoinType:  []byte(" NATURAL FULL JOIN "),
 			exp.CrossJoinType:        []byte(" CROSS JOIN "),
+			exp.CustomJoinType:       []byte(" "), // User need to fill in the join statement themselves
 		},
 
 		TimeFormat: time.RFC3339Nano,


### PR DESCRIPTION
resolves https://github.com/doug-martin/goqu/issues/423

Add a new `CustomJoin` type to allow users to fill in whatever non standard join statement they might use.

In my case of using ClickHouse, we use `ARRAY JOIN <nested col> AS <col>`, and with this change, it can now be written as

```go
goqu.Select("*").From("test").CustomJoin(goqu.L("ARRAY JOIN nested").As("foo"))
```
which should result in a query like

```sql
SELECT * FROM test ARRAY JOIN nested AS foo
```


`CustomJoin` will not add anything, and will take whatever the user passes it, so it's up to the user to make sure if the syntax of the `JOIN` statement is accurate or not.