### PR TITLE
fix: Update SQLITE3 dialect to allow for OnConflictUpdateWhere

### DIFF
--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -15,7 +15,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.SupportsLimitOnUpdate = true
 	opts.SupportsOrderByOnDelete = true
 	opts.SupportsLimitOnDelete = true
-	opts.SupportsConflictUpdateWhere = false
+	opts.SupportsConflictUpdateWhere = true
 	opts.SupportsInsertIgnoreSyntax = true
 	opts.SupportsConflictTarget = true
 	opts.SupportsMultipleUpdateTables = false


### PR DESCRIPTION
These days SQLITE3 supports `WHERE` clauses inside of a conflict `DO UPDATE`. This PR changes the SQLITE3 dialect to support that.

https://www.sqlite.org/lang_upsert.html

Relevant docs:
```
The only use for the WHERE clause at the end of the DO UPDATE is to optionally change the DO UPDATE into a no-op depending on the original and/or new values. For example:

    CREATE TABLE phonebook2(
      name TEXT PRIMARY KEY,
      phonenumber TEXT,
      validDate DATE
    );
    INSERT INTO phonebook2(name,phonenumber,validDate)
      VALUES('Alice','704-555-1212','2018-05-08')
      ON CONFLICT(name) DO UPDATE SET
        phonenumber=excluded.phonenumber,
        validDate=excluded.validDate
      WHERE excluded.validDate>phonebook2.validDate;

In this last example, the phonebook2 entry is only updated if the validDate for the newly inserted value is newer than the entry already in the table. If the table already contains an entry with the same name and a current validDate, then the WHERE clause causes the DO UPDATE to become a no-op. 
```