### PR TITLE
improve allocations in expression generator

### DIFF
--- a/delete_dataset.go
+++ b/delete_dataset.go
@@ -206,7 +206,9 @@ func (dd *DeleteDataset) SetError(err error) *DeleteDataset {
 // Errors:
 //   - There is an error generating the SQL
 func (dd *DeleteDataset) ToSQL() (sql string, params []interface{}, err error) {
-	return dd.deleteSQLBuilder().ToSQL()
+	builder := dd.deleteSQLBuilder()
+	defer sb.ReleaseSQLBuilder(builder)
+	return builder.ToSQL()
 }
 
 // Appends this Dataset's DELETE statement to the SQLBuilder

--- a/insert_dataset.go
+++ b/insert_dataset.go
@@ -230,7 +230,9 @@ func (id *InsertDataset) SetError(err error) *InsertDataset {
 //   - Rows of different lengths, (i.e. (Record{"name": "a"}, Record{"name": "a", "age": 10})
 //   - Error generating SQL
 func (id *InsertDataset) ToSQL() (sql string, params []interface{}, err error) {
-	return id.insertSQLBuilder().ToSQL()
+	builder := id.insertSQLBuilder()
+	defer sb.ReleaseSQLBuilder(builder)
+	return builder.ToSQL()
 }
 
 // Appends this Dataset's INSERT statement to the SQLBuilder
@@ -267,6 +269,20 @@ func (id *InsertDataset) insertSQLBuilder() sb.SQLBuilder {
 	buf := sb.NewSQLBuilder(id.isPrepared.Bool())
 	if id.err != nil {
 		return buf.SetError(id.err)
+	}
+	if vals := id.clauses.Vals(); len(vals) > 0 {
+		maxCols := 0
+		totalArgs := 0
+		for _, row := range vals {
+			c := len(row)
+			totalArgs += c
+			if c > maxCols {
+				maxCols = c
+			}
+		}
+		if totalArgs > 0 {
+			buf.GrowArgs(totalArgs)
+		}
 	}
 	id.dialect.ToInsertSQL(buf, id.clauses)
 	return buf

--- a/internal/sb/sql_builder.go
+++ b/internal/sb/sql_builder.go
@@ -2,6 +2,7 @@ package sb
 
 import (
 	"bytes"
+	"sync"
 )
 
 // Builder that is composed of a bytes.Buffer. It is used internally and by adapters to build SQL statements
@@ -13,6 +14,8 @@ type (
 		Write(p []byte) SQLBuilder
 		WriteStrings(ss ...string) SQLBuilder
 		WriteRunes(r ...rune) SQLBuilder
+		GrowArgs(n int) SQLBuilder
+		GrowBuffer(n int) SQLBuilder
 		IsPrepared() bool
 		CurrentArgPosition() int
 		ToSQL() (sql string, args []interface{}, err error)
@@ -23,17 +26,23 @@ type (
 		isPrepared bool
 		// Current Number of arguments, used by adapters that need positional placeholders
 		currentArgPosition int
-		args               []interface{}
+		args               []any
 		err                error
 	}
 )
 
 func NewSQLBuilder(isPrepared bool) SQLBuilder {
+	sb := builderPool.Get().(*sqlBuilder)
+	sb.isPrepared = isPrepared
+	return sb
+}
+
+func newSQLBuilder(isPrepared bool) *sqlBuilder {
 	return &sqlBuilder{
 		buf:                &bytes.Buffer{},
-		isPrepared:         isPrepared,
-		args:               make([]interface{}, 0),
+		args:               make([]any, 0, 4),
 		currentArgPosition: 1,
+		isPrepared:         isPrepared,
 	}
 }
 
@@ -57,8 +66,20 @@ func (b *sqlBuilder) Write(bs []byte) SQLBuilder {
 
 func (b *sqlBuilder) WriteStrings(ss ...string) SQLBuilder {
 	if b.err == nil {
-		for _, s := range ss {
-			b.buf.WriteString(s)
+		switch len(ss) {
+		case 0:
+			return b
+		case 1:
+			b.buf.WriteString(ss[0])
+		default:
+			totalSize := 0
+			for _, s := range ss {
+				totalSize += len(s)
+			}
+			b.buf.Grow(totalSize)
+			for _, s := range ss {
+				b.buf.WriteString(s)
+			}
 		}
 	}
 	return b
@@ -66,9 +87,47 @@ func (b *sqlBuilder) WriteStrings(ss ...string) SQLBuilder {
 
 func (b *sqlBuilder) WriteRunes(rs ...rune) SQLBuilder {
 	if b.err == nil {
-		for _, r := range rs {
-			b.buf.WriteRune(r)
+		switch len(rs) {
+		case 0:
+			return b
+		case 1:
+			b.buf.WriteRune(rs[0])
+		case 2:
+			b.buf.Grow(2)
+			b.buf.WriteRune(rs[0])
+			b.buf.WriteRune(rs[1])
+		default:
+			b.buf.WriteString(string(rs))
 		}
+	}
+	return b
+}
+
+func (b *sqlBuilder) GrowArgs(n int) SQLBuilder {
+	if b.err != nil || n <= 0 {
+		return b
+	}
+	currentLen := len(b.args)
+	needed := currentLen + n
+	if cap(b.args) >= needed {
+		return b
+	}
+	newCap := cap(b.args)
+	if newCap == 0 {
+		newCap = 1
+	}
+	for newCap < needed {
+		newCap *= 2
+	}
+	na := make([]interface{}, currentLen, newCap)
+	copy(na, b.args)
+	b.args = na
+	return b
+}
+
+func (b *sqlBuilder) GrowBuffer(n int) SQLBuilder {
+	if b.err == nil && n > 0 {
+		b.buf.Grow(n)
 	}
 	return b
 }
@@ -98,4 +157,25 @@ func (b *sqlBuilder) ToSQL() (sql string, args []interface{}, err error) {
 		return sql, args, b.err
 	}
 	return b.buf.String(), b.args, nil
+}
+
+var builderPool = sync.Pool{
+	New: func() interface{} {
+		return newSQLBuilder(false)
+	},
+}
+
+func (b *sqlBuilder) reset() {
+	b.buf.Reset()
+	b.args = make([]any, 0, 4)
+	b.err = nil
+	b.isPrepared = false
+	b.currentArgPosition = 1
+}
+
+func ReleaseSQLBuilder(b SQLBuilder) {
+	if sbImpl, ok := b.(*sqlBuilder); ok {
+		sbImpl.reset()
+		builderPool.Put(sbImpl)
+	}
 }

--- a/internal/sb/sql_builder_test.go
+++ b/internal/sb/sql_builder_test.go
@@ -1,0 +1,87 @@
+package sb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Ensures that after calling ToSQL(), the returned args slice is not mutated
+// by subsequent calls to reset() and further writes on the same builder.
+func TestSQLBuilder_ResetDoesNotMutateReturnedArgs(t *testing.T) {
+	// Use the unexported constructor to deterministically operate on a single builder instance.
+	sb := newSQLBuilder(false)
+
+	// Populate with initial args and capture the returned args slice from ToSQL.
+	sb.WriteArg("first", 2)
+	_, argsBefore, err := sb.ToSQL()
+	if err != nil {
+		t.Fatalf("unexpected error from ToSQL: %v", err)
+	}
+	if len(argsBefore) != 2 {
+		t.Fatalf("expected 2 args before reset, got %d", len(argsBefore))
+	}
+
+	// Keep a deep copy for comparison after reset and reuse.
+	argsSnapshot := append([]interface{}(nil), argsBefore...)
+
+	// Reset and reuse the builder; if reset reuses the same backing array for args,
+	// the following WriteArg calls would overwrite argsBefore's elements.
+	sb.reset()
+	sb.WriteArg("new1", "new2")
+
+	// Verify that the previously returned args slice remains unchanged.
+	if !reflect.DeepEqual(argsBefore, argsSnapshot) {
+		t.Fatalf("args returned by first ToSQL were mutated after reset+reuse; before=%v after=%v", argsSnapshot, argsBefore)
+	}
+}
+
+// Ensures that releasing a builder resets its fields, including creating a fresh args slice
+// (cap reset to 4 as per implementation), clearing buffer, error, prepared flag, and arg position.
+func TestReleaseSQLBuilderResetsState(t *testing.T) {
+	b := NewSQLBuilder(true)
+	// Exercise fields so we can verify they get reset.
+	b.WriteStrings("SELECT ")
+	b.WriteRunes('1')
+	b.WriteArg(123)
+	// Set an error to make sure it's cleared by reset via Release.
+	b.SetError(assertErr{})
+
+	// Keep a reference to the underlying implementation for inspection after release.
+	sbImpl, ok := b.(*sqlBuilder)
+	if !ok {
+		t.Fatalf("expected *sqlBuilder implementation")
+	}
+
+	ReleaseSQLBuilder(b)
+
+	// Buffer should be cleared.
+	if got := sbImpl.buf.String(); got != "" {
+		t.Fatalf("buffer not reset; got %q", got)
+	}
+	// Args should be a fresh slice with len 0 and cap 4.
+	if ln := len(sbImpl.args); ln != 0 {
+		t.Fatalf("args length not reset; got %d, want 0", ln)
+	}
+	if cap(sbImpl.args) != 4 {
+		t.Fatalf("args capacity not reset; got %d, want 4", cap(sbImpl.args))
+	}
+	// Error cleared
+	if sbImpl.err != nil {
+		t.Fatalf("error not reset; got %v", sbImpl.err)
+	}
+	// Prepared flag reset
+	if sbImpl.isPrepared {
+		t.Fatalf("isPrepared not reset; got true, want false")
+	}
+	// Arg position reset
+	if sbImpl.currentArgPosition != 1 {
+		t.Fatalf("currentArgPosition not reset; got %d, want 1", sbImpl.currentArgPosition)
+	}
+}
+
+// assertErr is a sentinel error type for testing SetError/Reset clearing.
+type assertErr struct{}
+
+func (assertErr) Error() string { return "assert" }
+
+

--- a/select_dataset.go
+++ b/select_dataset.go
@@ -543,7 +543,9 @@ func (sd *SelectDataset) SetError(err error) *SelectDataset {
 // Errors:
 //   - There is an error generating the SQL
 func (sd *SelectDataset) ToSQL() (sql string, params []interface{}, err error) {
-	return sd.selectSQLBuilder().ToSQL()
+	builder := sd.selectSQLBuilder()
+	defer sb.ReleaseSQLBuilder(builder)
+	return builder.ToSQL()
 }
 
 // Generates the SELECT sql, and returns an Exec struct with the sql set to the SELECT statement

--- a/sqlgen/bench_expression_sql_generator_test.go
+++ b/sqlgen/bench_expression_sql_generator_test.go
@@ -1,0 +1,253 @@
+package sqlgen_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/doug-martin/goqu/v9/exp"
+	"github.com/doug-martin/goqu/v9/internal/sb"
+	"github.com/doug-martin/goqu/v9/sqlgen"
+)
+
+func newESG(opts *sqlgen.SQLDialectOptions, prepared bool) (sqlgen.ExpressionSQLGenerator, sb.SQLBuilder) {
+	return sqlgen.NewExpressionSQLGenerator("bench", opts), sb.NewSQLBuilder(prepared)
+}
+
+// --- INSERT: single row, many columns; and multi-row bulk ---
+
+func BenchmarkExpressionSQLGenerator_Insert(b *testing.B) {
+	opts := sqlgen.DefaultDialectOptions()
+	optsNums := sqlgen.DefaultDialectOptions()
+	optsNums.IncludePlaceholderNum = true
+	optsNums.PlaceHolderFragment = []byte("$")
+
+	columns := 128
+	rows := 32
+
+	// Precompute identifiers and sample values
+	colNames := make([]interface{}, columns)
+	for i := 0; i < columns; i++ {
+		colNames[i] = fmt.Sprintf("c_%03d", i)
+	}
+	colList := exp.NewColumnListExpression(colNames...)
+	// Construct one row worth of mixed values
+	rowVals := make([]interface{}, columns)
+	for i := 0; i < columns; i++ {
+		switch i % 5 {
+		case 0:
+			rowVals[i] = i
+		case 1:
+			rowVals[i] = fmt.Sprintf("val_%d", i)
+		case 2:
+			rowVals[i] = (i%2 == 0)
+		case 3:
+			rowVals[i] = time.Unix(int64(1_700_000_000+i), 0).UTC()
+		default:
+			rowVals[i] = []byte("xyz")
+		}
+	}
+	// Precompute multiple rows as copies of rowVals
+	rowsVals := make([][]interface{}, rows)
+	for r := 0; r < rows; r++ {
+		rowsVals[r] = rowVals
+	}
+
+	types := []struct {
+		name     string
+		prepared bool
+		opts     *sqlgen.SQLDialectOptions
+	}{
+		{"Unprepared", false, opts},
+		{"Prepared", true, opts},
+		{"PreparedWithNums", true, optsNums},
+	}
+
+	for _, tt := range types {
+		b.Run(tt.name+"/SingleRowManyCols", func(b *testing.B) {
+			esg, _ := newESG(tt.opts, tt.prepared)
+			ident := exp.NewIdentifierExpression("", "bench_insert", "")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, builder := newESG(tt.opts, tt.prepared)
+				builder.WriteStrings("INSERT INTO ")
+				esg.Generate(builder, ident)
+				builder.WriteStrings(" (")
+				esg.Generate(builder, colList)
+				builder.WriteStrings(") VALUES ")
+				esg.Generate(builder, rowVals)
+				if _, _, err := builder.ToSQL(); err != nil {
+					b.Fatalf("ToSQL error: %v", err)
+				}
+			}
+		})
+
+		b.Run(tt.name+"/MultiRowBulk", func(b *testing.B) {
+			esg, _ := newESG(tt.opts, tt.prepared)
+			ident := exp.NewIdentifierExpression("", "bench_insert_bulk", "")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, builder := newESG(tt.opts, tt.prepared)
+				builder.WriteStrings("INSERT INTO ")
+				esg.Generate(builder, ident)
+				builder.WriteStrings(" (")
+				esg.Generate(builder, colList)
+				builder.WriteStrings(") VALUES ")
+				for r := 0; r < rows; r++ {
+					esg.Generate(builder, rowsVals[r])
+					if r < rows-1 {
+						builder.WriteRunes(',', ' ')
+					}
+				}
+				if _, _, err := builder.ToSQL(); err != nil {
+					b.Fatalf("ToSQL error: %v", err)
+				}
+				sb.ReleaseSQLBuilder(builder)
+			}
+		})
+	}
+}
+
+// --- UPDATE: many columns with complex WHERE ---
+
+func BenchmarkExpressionSQLGenerator_Update(b *testing.B) {
+	opts := sqlgen.DefaultDialectOptions()
+	optsNums := sqlgen.DefaultDialectOptions()
+	optsNums.IncludePlaceholderNum = true
+	optsNums.PlaceHolderFragment = []byte("$")
+
+	setCols := 64
+	inSize := 256
+
+	// Precompute column identifiers and values
+	setExprs := make([]exp.UpdateExpression, setCols)
+	for i := 0; i < setCols; i++ {
+		col := exp.NewIdentifierExpression("", "", fmt.Sprintf("c_%03d", i))
+		setExprs[i] = col.Set(i)
+	}
+	// WHERE: a big AND of equality and IN clauses
+	andExprs := make([]exp.Expression, 0, 64)
+	for i := 0; i < 48; i++ {
+		col := exp.NewIdentifierExpression("", "", fmt.Sprintf("w_%03d", i))
+		andExprs = append(andExprs, col.Eq(i))
+	}
+	// Large IN clauses
+	values := make([]int64, inSize)
+	for i := range values {
+		values[i] = int64(i)
+	}
+	andExprs = append(andExprs,
+		exp.NewIdentifierExpression("", "", "user_id").In(values),
+		exp.NewIdentifierExpression("", "", "status").In([]string{"new", "ok", "hold", "done"}),
+	)
+	where := exp.NewExpressionList(exp.AndType, andExprs...)
+
+	types := []struct {
+		name     string
+		prepared bool
+		opts     *sqlgen.SQLDialectOptions
+	}{
+		{"Unprepared", false, opts},
+		{"Prepared", true, opts},
+		{"PreparedWithNums", true, optsNums},
+	}
+
+	for _, tt := range types {
+		b.Run(tt.name, func(b *testing.B) {
+			esg, _ := newESG(tt.opts, tt.prepared)
+			ident := exp.NewIdentifierExpression("", "bench_update", "")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, builder := newESG(tt.opts, tt.prepared)
+				builder.WriteStrings("UPDATE ")
+				esg.Generate(builder, ident)
+				builder.WriteStrings(" SET ")
+				for j, se := range setExprs {
+					esg.Generate(builder, se)
+					if j < len(setExprs)-1 {
+						builder.WriteRunes(',', ' ')
+					}
+				}
+				builder.WriteStrings(" WHERE ")
+				esg.Generate(builder, where)
+				if _, _, err := builder.ToSQL(); err != nil {
+					b.Fatalf("ToSQL error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// --- SELECT: large WHERE with multiple IN and LIKEs ---
+
+func BenchmarkExpressionSQLGenerator_Select(b *testing.B) {
+	opts := sqlgen.DefaultDialectOptions()
+	optsNums := sqlgen.DefaultDialectOptions()
+	optsNums.IncludePlaceholderNum = true
+	optsNums.PlaceHolderFragment = []byte("$")
+
+	cols := 32
+	preds := 200
+	inSize := 512
+
+	colNames := make([]interface{}, cols)
+	for i := 0; i < cols; i++ {
+		colNames[i] = fmt.Sprintf("c_%03d", i)
+	}
+	colList := exp.NewColumnListExpression(colNames...)
+
+	// WHERE predicates
+	ps := make([]exp.Expression, 0, preds)
+	for i := 0; i < preds-3; i++ {
+		c := exp.NewIdentifierExpression("", "", fmt.Sprintf("p_%03d", i))
+		if i%10 == 0 {
+			ps = append(ps, c.Like("prefix%"))
+		} else {
+			ps = append(ps, c.Eq(i))
+		}
+	}
+	bigIn := make([]int64, inSize)
+	for i := range bigIn {
+		bigIn[i] = int64(i)
+	}
+	ps = append(ps,
+		exp.NewIdentifierExpression("", "", "id").In(bigIn),
+		exp.NewIdentifierExpression("", "", "kind").In([]string{"a", "b", "c", "d"}),
+		exp.NewIdentifierExpression("", "", "flag").Eq(true),
+	)
+	where := exp.NewExpressionList(exp.AndType, ps...)
+
+	types := []struct {
+		name     string
+		prepared bool
+		opts     *sqlgen.SQLDialectOptions
+	}{
+		{"Unprepared", false, opts},
+		{"Prepared", true, opts},
+		{"PreparedWithNums", true, optsNums},
+	}
+
+	for _, tt := range types {
+		b.Run(tt.name, func(b *testing.B) {
+			esg, _ := newESG(tt.opts, tt.prepared)
+			tbl := exp.NewIdentifierExpression("", "bench_select", "")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, builder := newESG(tt.opts, tt.prepared)
+				builder.WriteStrings("SELECT ")
+				esg.Generate(builder, colList)
+				builder.WriteStrings(" FROM ")
+				esg.Generate(builder, tbl)
+				builder.WriteStrings(" WHERE ")
+				esg.Generate(builder, where)
+				if _, _, err := builder.ToSQL(); err != nil {
+					b.Fatalf("ToSQL error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -26,6 +27,7 @@ type (
 	expressionSQLGenerator struct {
 		dialect        string
 		dialectOptions *SQLDialectOptions
+		scratchBuffer  []byte
 	}
 )
 
@@ -66,7 +68,7 @@ func errLateralNotSupported(dialect string) error {
 }
 
 func NewExpressionSQLGenerator(dialect string, do *SQLDialectOptions) ExpressionSQLGenerator {
-	return &expressionSQLGenerator{dialect: dialect, dialectOptions: do}
+	return &expressionSQLGenerator{dialect: dialect, dialectOptions: do, scratchBuffer: make([]byte, 0, 32)}
 }
 
 func (esg *expressionSQLGenerator) Dialect() string {
@@ -86,6 +88,20 @@ func (esg *expressionSQLGenerator) Generate(b sb.SQLBuilder, val interface{}) {
 	switch v := val.(type) {
 	case exp.Expression:
 		esg.expressionSQL(b, v)
+	case driver.Valuer:
+		// See https://github.com/golang/go/commit/0ce1d79a6a771f7449ec493b993ed2a720917870
+		if rv := reflect.ValueOf(val); rv.Kind() == reflect.Ptr &&
+			rv.IsNil() &&
+			rv.Type().Elem().Implements(valuerReflectType) {
+			esg.literalNil(b)
+			return
+		}
+		dVal, err := v.Value()
+		if err != nil {
+			b.SetError(err)
+			return
+		}
+		esg.Generate(b, dVal)
 	case int:
 		esg.literalInt(b, int64(v))
 	case int32:
@@ -108,23 +124,133 @@ func (esg *expressionSQLGenerator) Generate(b sb.SQLBuilder, val interface{}) {
 			return
 		}
 		esg.literalTime(b, *v)
-	case driver.Valuer:
-		// See https://github.com/golang/go/commit/0ce1d79a6a771f7449ec493b993ed2a720917870
-		if rv := reflect.ValueOf(val); rv.Kind() == reflect.Ptr &&
-			rv.IsNil() &&
-			rv.Type().Elem().Implements(valuerReflectType) {
-			esg.literalNil(b)
-			return
-		}
-		dVal, err := v.Value()
-		if err != nil {
-			b.SetError(err)
-			return
-		}
-		esg.Generate(b, dVal)
+	case []interface{}:
+		esg.sliceInterfaceSQL(b, v)
+	case []int64:
+		esg.sliceInt64SQL(b, v)
+	case []int:
+		esg.sliceIntSQL(b, v)
+	case []string:
+		esg.sliceStringSQL(b, v)
+	case []float64:
+		esg.sliceFloat64SQL(b, v)
+	case []bool:
+		esg.sliceBoolSQL(b, v)
+	case []time.Time:
+		esg.sliceTimeSQL(b, v)
+	case []byte:
+		esg.literalBytes(b, v)
+	case []exp.CommonTableExpression:
+		esg.commonTablesSliceSQL(b, v)
 	default:
 		esg.reflectSQL(b, val)
 	}
+}
+
+// Typed slice fast paths to avoid reflection-heavy paths in hot loops
+func (esg *expressionSQLGenerator) sliceInt64SQL(b sb.SQLBuilder, s []int64) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 16)
+	for i, v := range s {
+		esg.Generate(b, v)
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
+}
+
+func (esg *expressionSQLGenerator) sliceIntSQL(b sb.SQLBuilder, s []int) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 16)
+	for i, v := range s {
+		esg.Generate(b, int64(v))
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
+}
+
+func (esg *expressionSQLGenerator) sliceStringSQL(b sb.SQLBuilder, s []string) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 16)
+	for i, v := range s {
+		esg.Generate(b, v)
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
+}
+
+func (esg *expressionSQLGenerator) sliceFloat64SQL(b sb.SQLBuilder, s []float64) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 16)
+	for i, v := range s {
+		esg.Generate(b, v)
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
+}
+
+func (esg *expressionSQLGenerator) sliceBoolSQL(b sb.SQLBuilder, s []bool) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 10)
+	for i, v := range s {
+		esg.Generate(b, v)
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
+}
+
+func (esg *expressionSQLGenerator) sliceTimeSQL(b sb.SQLBuilder, s []time.Time) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 32)
+	for i, v := range s {
+		esg.Generate(b, v)
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
+}
+
+func (esg *expressionSQLGenerator) sliceInterfaceSQL(b sb.SQLBuilder, s []interface{}) {
+	b.WriteRunes(esg.dialectOptions.LeftParenRune)
+	if b.IsPrepared() {
+		b.GrowArgs(len(s))
+	}
+	b.GrowBuffer(len(s) * 16)
+	for i, v := range s {
+		esg.Generate(b, v)
+		if i < len(s)-1 {
+			b.WriteRunes(esg.dialectOptions.CommaRune, esg.dialectOptions.SpaceRune)
+		}
+	}
+	b.WriteRunes(esg.dialectOptions.RightParenRune)
 }
 
 func (esg *expressionSQLGenerator) reflectSQL(b sb.SQLBuilder, val interface{}) {
@@ -134,14 +260,7 @@ func (esg *expressionSQLGenerator) reflectSQL(b sb.SQLBuilder, val interface{}) 
 	case util.IsInvalid(valKind):
 		esg.literalNil(b)
 	case util.IsSlice(valKind):
-		switch t := val.(type) {
-		case []byte:
-			esg.literalBytes(b, t)
-		case []exp.CommonTableExpression:
-			esg.commonTablesSliceSQL(b, t)
-		default:
-			esg.sliceValueSQL(b, v)
-		}
+		esg.sliceValueSQL(b, v)
 	case util.IsInt(valKind):
 		esg.Generate(b, v.Int())
 	case util.IsUint(valKind):
@@ -211,7 +330,8 @@ func (esg *expressionSQLGenerator) expressionSQL(b sb.SQLBuilder, expression exp
 func (esg *expressionSQLGenerator) placeHolderSQL(b sb.SQLBuilder, i interface{}) {
 	b.Write(esg.dialectOptions.PlaceHolderFragment)
 	if esg.dialectOptions.IncludePlaceholderNum {
-		b.WriteStrings(strconv.FormatInt(int64(b.CurrentArgPosition()), 10))
+		nb := strconv.AppendInt(esg.scratchBuffer[:0], int64(b.CurrentArgPosition()), 10)
+		b.Write(nb)
 	}
 	b.WriteArg(i)
 }
@@ -234,6 +354,7 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 		return
 	}
 	schema, table, col := ident.GetSchema(), ident.GetTable(), ident.GetCol()
+	b.GrowBuffer(len(schema) + len(table) + 32)
 	if schema != esg.dialectOptions.EmptyString {
 		b.WriteRunes(esg.dialectOptions.QuoteRune).
 			WriteStrings(schema).
@@ -314,7 +435,9 @@ func (esg *expressionSQLGenerator) literalFloat(b sb.SQLBuilder, f float64) {
 		esg.placeHolderSQL(b, f)
 		return
 	}
-	b.WriteStrings(strconv.FormatFloat(f, 'f', -1, 64))
+	buf := esg.scratchBuffer[:0]
+	buf = strconv.AppendFloat(buf, f, 'f', -1, 64)
+	b.Write(buf)
 }
 
 // Generates SQL for an int value
@@ -323,7 +446,9 @@ func (esg *expressionSQLGenerator) literalInt(b sb.SQLBuilder, i int64) {
 		esg.placeHolderSQL(b, i)
 		return
 	}
-	b.WriteStrings(strconv.FormatInt(i, 10))
+	buf := esg.scratchBuffer[:0]
+	buf = strconv.AppendInt(buf, i, 10)
+	b.Write(buf)
 }
 
 // Generates SQL for a string
@@ -332,6 +457,7 @@ func (esg *expressionSQLGenerator) literalString(b sb.SQLBuilder, s string) {
 		esg.placeHolderSQL(b, s)
 		return
 	}
+	b.GrowBuffer(len(s) * 2)
 	b.WriteRunes(esg.dialectOptions.StringQuote)
 	for _, char := range s {
 		if e, ok := esg.dialectOptions.EscapedRunes[char]; ok {
@@ -340,7 +466,6 @@ func (esg *expressionSQLGenerator) literalString(b sb.SQLBuilder, s string) {
 			b.WriteRunes(char)
 		}
 	}
-
 	b.WriteRunes(esg.dialectOptions.StringQuote)
 }
 
@@ -350,6 +475,7 @@ func (esg *expressionSQLGenerator) literalBytes(b sb.SQLBuilder, bs []byte) {
 		esg.placeHolderSQL(b, bs)
 		return
 	}
+	b.GrowBuffer(len(bs) * 2)
 	b.WriteRunes(esg.dialectOptions.StringQuote)
 	i := 0
 	for len(bs) > 0 {
@@ -542,13 +668,26 @@ func (esg *expressionSQLGenerator) literalExpressionSQL(b sb.SQLBuilder, literal
 	args := literal.Args()
 	if argsLen := len(args); argsLen > 0 {
 		currIndex := 0
-		for _, char := range l {
-			if char == replacementRune && currIndex < argsLen {
+		start := 0
+		for {
+			i := strings.IndexByte(l[start:], byte(replacementRune))
+			if i == -1 {
+				break
+			}
+			i += start
+			if i > start {
+				b.WriteStrings(l[start:i])
+			}
+			if currIndex < argsLen {
 				esg.Generate(b, args[currIndex])
 				currIndex++
 			} else {
-				b.WriteRunes(char)
+				b.WriteRunes(replacementRune)
 			}
+			start = i + 1
+		}
+		if start < len(l) {
+			b.WriteStrings(l[start:])
 		}
 		return
 	}

--- a/truncate_dataset.go
+++ b/truncate_dataset.go
@@ -151,7 +151,9 @@ func (td *TruncateDataset) SetError(err error) *TruncateDataset {
 // Errors:
 //   - There is an error generating the SQL
 func (td *TruncateDataset) ToSQL() (sql string, params []interface{}, err error) {
-	return td.truncateSQLBuilder().ToSQL()
+	builder := td.truncateSQLBuilder()
+	defer sb.ReleaseSQLBuilder(builder)
+	return builder.ToSQL()
 }
 
 // Generates the TRUNCATE sql, and returns an Exec struct with the sql set to the TRUNCATE statement

--- a/update_dataset.go
+++ b/update_dataset.go
@@ -208,7 +208,9 @@ func (ud *UpdateDataset) SetError(err error) *UpdateDataset {
 // Errors:
 //   - There is an error generating the SQL
 func (ud *UpdateDataset) ToSQL() (sql string, params []interface{}, err error) {
-	return ud.updateSQLBuilder().ToSQL()
+	builder := ud.updateSQLBuilder()
+	defer sb.ReleaseSQLBuilder(builder)
+	return builder.ToSQL()
 }
 
 // Appends this Dataset's UPDATE statement to the SQLBuilder


### PR DESCRIPTION
- We noticed heavy allocation generation in a production workflow, which then generates lots of garbage collection pressure, coming from the dataset -> toSQL generation.

- Adds benchmarks around the Expression SQL generator

- Adds pooling of instances

- Adds GrowBuffer/GrowArgs to upsize buffers when we know large writes are coming

- Adds more native / non-reflection based writers

- other minor optimizations

```
benchmark                                                                       old allocs     new allocs     delta
BenchmarkExpressionSQLGenerator_Insert/Unprepared/SingleRowManyCols-8           1626           1596           -1.85%
BenchmarkExpressionSQLGenerator_Insert/Unprepared/MultiRowBulk-8                35730          34695          -2.90%
BenchmarkExpressionSQLGenerator_Insert/Prepared/SingleRowManyCols-8             868            864            -0.46%
BenchmarkExpressionSQLGenerator_Insert/Prepared/MultiRowBulk-8                  11263          11239          -0.21%
BenchmarkExpressionSQLGenerator_Insert/PreparedWithNums/SingleRowManyCols-8     1025           864            -15.71%
BenchmarkExpressionSQLGenerator_Insert/PreparedWithNums/MultiRowBulk-8          19357          11239          -41.94%
BenchmarkExpressionSQLGenerator_Update/Unprepared-8                             1754           976            -44.36%
BenchmarkExpressionSQLGenerator_Update/Prepared-8                               1595           1340           -15.99%
BenchmarkExpressionSQLGenerator_Update/PreparedWithNums-8                       2240           1340           -40.18%
BenchmarkExpressionSQLGenerator_Select/Unprepared-8                             3961           2520           -36.38%
BenchmarkExpressionSQLGenerator_Select/Prepared-8                               3585           3330           -7.11%
BenchmarkExpressionSQLGenerator_Select/PreparedWithNums-8                       4912           3331           -32.19%
```